### PR TITLE
[codex] Improve store browsing and shopping comparison flows

### DIFF
--- a/app/api/grocery-search/cache-selection/__tests__/route.test.ts
+++ b/app/api/grocery-search/cache-selection/__tests__/route.test.ts
@@ -4,6 +4,7 @@ const { mockResolveStandardizedIngredientId, mockBatchStandardizeAndMatch, mockI
   vi.hoisted(() => ({
     mockResolveStandardizedIngredientId: vi.fn(),
     mockBatchStandardizeAndMatch: vi.fn(),
+    // Kept in mock object so the module import resolves, but must never be called.
     mockInsertPrice: vi.fn(),
   }))
 
@@ -29,47 +30,61 @@ describe("POST /api/grocery-search/cache-selection", () => {
     vi.clearAllMocks()
     mockResolveStandardizedIngredientId.mockResolvedValue("std_1")
     mockBatchStandardizeAndMatch.mockResolvedValue(1)
-    mockInsertPrice.mockResolvedValue(true)
   })
 
-  it("returns 400 when required fields are missing", async () => {
-    const response = await POST(makeRequest({ store: "walmart" }) as any)
+  // ── Validation ──────────────────────────────────────────────────────────────
 
+  it("returns 400 when store/product/identifier are missing", async () => {
+    const response = await POST(makeRequest({ store: "walmart" }) as any)
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({
       error: "store, product, and either searchTerm or standardizedIngredientId are required",
     })
   })
 
-  it("returns 400 when the selected product is invalid", async () => {
+  it("returns 400 when product.title is empty", async () => {
     const response = await POST(
       makeRequest({
         searchTerm: "milk",
         store: "walmart",
-        product: { id: "prod_1", title: "", price: 0 },
+        product: { id: "p1", title: "", price: 3.99 },
       }) as any
     )
-
     expect(response.status).toBe(400)
-    expect(await response.json()).toEqual({
-      error: "product.id, product.title, and positive product.price are required",
-    })
   })
 
-  it("resolves a standardized ingredient id from the search term when one is not provided", async () => {
+  it("returns 400 when product.price is zero or missing", async () => {
+    const response = await POST(
+      makeRequest({
+        searchTerm: "milk",
+        store: "walmart",
+        product: { id: "p1", title: "Milk", price: 0 },
+      }) as any
+    )
+    expect(response.status).toBe(400)
+  })
+
+  it("returns 400 when product.id is missing", async () => {
+    const response = await POST(
+      makeRequest({
+        searchTerm: "milk",
+        store: "walmart",
+        product: { title: "Milk", price: 3.99 },
+      }) as any
+    )
+    expect(response.status).toBe(400)
+  })
+
+  // ── Ingredient resolution ────────────────────────────────────────────────────
+
+  it("resolves ingredient id from searchTerm when standardizedIngredientId is absent", async () => {
     const response = await POST(
       makeRequest({
         searchTerm: "whole milk",
         store: "Walmart",
         zipCode: "94110",
         groceryStoreId: "store_1",
-        product: {
-          id: "prod_1",
-          title: "Organic Whole Milk",
-          price: 4.99,
-          unit: "gallon",
-          rawUnit: "gallon",
-        },
+        product: { id: "prod_1", title: "Organic Whole Milk", price: 4.99, unit: "gallon", rawUnit: "gallon" },
       }) as any
     )
 
@@ -88,82 +103,111 @@ describe("POST /api/grocery-search/cache-selection", () => {
       }),
     ])
     expect(response.status).toBe(200)
-    expect(await response.json()).toMatchObject({
-      success: true,
-      inserted: 1,
-      cachedViaFallback: false,
-      standardizedIngredientId: "std_1",
-    })
+    const body = await response.json()
+    expect(body).toMatchObject({ success: true, inserted: 1, standardizedIngredientId: "std_1" })
+    // cachedViaFallback was removed — orphaned insertPrice rows are invisible to get_pricing
+    expect(body).not.toHaveProperty("cachedViaFallback")
   })
 
-  it("falls back to direct cache insertion when the RPC insert path returns zero rows", async () => {
+  it("uses provided standardizedIngredientId directly without calling resolveStandardizedIngredientId", async () => {
+    const response = await POST(
+      makeRequest({
+        standardizedIngredientId: "std_direct",
+        store: "kroger",
+        product: { id: "prod_2", title: "Butter", price: 3.50 },
+      }) as any
+    )
+
+    expect(mockResolveStandardizedIngredientId).not.toHaveBeenCalled()
+    expect(mockBatchStandardizeAndMatch).toHaveBeenCalledWith([
+      expect.objectContaining({ standardizedIngredientId: "std_direct" }),
+    ])
+    expect(response.status).toBe(200)
+  })
+
+  it("returns 500 when standardized ingredient id cannot be resolved from searchTerm", async () => {
+    mockResolveStandardizedIngredientId.mockResolvedValue(null)
+
+    const response = await POST(
+      makeRequest({
+        searchTerm: "unknown_xyzzy",
+        store: "walmart",
+        product: { id: "p9", title: "Mystery", price: 5 },
+      }) as any
+    )
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({ error: "Could not resolve standardized ingredient" })
+  })
+
+  // ── Persistence failure path ─────────────────────────────────────────────────
+
+  it("returns 500 — and does NOT call insertPrice — when batchStandardizeAndMatch returns 0", async () => {
+    // batchStandardizeAndMatch returning 0 means the RPC errored or skipped all items.
+    // Previously a direct insertPrice fallback was used, but those rows have no
+    // product_mapping_id and are invisible to get_pricing (which joins through
+    // product_mappings). The fallback was removed to avoid creating orphaned rows.
     mockBatchStandardizeAndMatch.mockResolvedValue(0)
 
     const response = await POST(
       makeRequest({
         standardizedIngredientId: "std_42",
         store: "Target",
-        product: {
-          id: "prod_42",
-          title: "Sea Salt",
-          price: 2.5,
-          image_url: "https://cdn.example.com/salt.png",
-          location: "Aisle 4",
-        },
-      }) as any
-    )
-
-    expect(mockInsertPrice).toHaveBeenCalledWith(
-      expect.objectContaining({
-        standardizedIngredientId: "std_42",
-        store: "target",
-        productName: "Sea Salt",
-        productId: "prod_42",
-        price: 2.5,
-        imageUrl: "https://cdn.example.com/salt.png",
-        location: "Aisle 4",
-      })
-    )
-    expect(response.status).toBe(200)
-    expect(await response.json()).toMatchObject({
-      success: true,
-      inserted: 0,
-      cachedViaFallback: true,
-    })
-  })
-
-  it("returns 500 when a standardized ingredient id cannot be resolved", async () => {
-    mockResolveStandardizedIngredientId.mockResolvedValue(null)
-
-    const response = await POST(
-      makeRequest({
-        searchTerm: "mystery ingredient",
-        store: "walmart",
-        product: { id: "prod_9", title: "Mystery", price: 5 },
+        product: { id: "prod_42", title: "Sea Salt", price: 2.50 },
       }) as any
     )
 
     expect(response.status).toBe(500)
-    expect(await response.json()).toEqual({
-      error: "Could not resolve standardized ingredient",
-    })
+    expect(await response.json()).toEqual({ error: "Failed to cache selection" })
+    expect(mockInsertPrice).not.toHaveBeenCalled()
   })
 
-  it("returns 500 when the fallback insert fails", async () => {
-    mockBatchStandardizeAndMatch.mockResolvedValue(0)
-    mockInsertPrice.mockResolvedValue(false)
+  // ── Payload normalisation ────────────────────────────────────────────────────
 
-    const response = await POST(
+  it("normalises store name to lowercase in the batchStandardizeAndMatch payload", async () => {
+    await POST(
+      makeRequest({
+        standardizedIngredientId: "std_1",
+        store: "Whole Foods",
+        product: { id: "p1", title: "Apples", price: 1.99 },
+      }) as any
+    )
+
+    expect(mockBatchStandardizeAndMatch).toHaveBeenCalledWith([
+      expect.objectContaining({ store: "whole foods" }),
+    ])
+  })
+
+  it("passes null for optional fields when they are absent from the request", async () => {
+    await POST(
       makeRequest({
         standardizedIngredientId: "std_1",
         store: "aldi",
-        product: { id: "prod_1", title: "Spinach", price: 2.99 },
+        product: { id: "p1", title: "Eggs", price: 2.99 },
       }) as any
     )
 
-    expect(response.status).toBe(500)
-    expect(await response.json()).toEqual({
-      error: "Failed to cache selection",
-    })
+    expect(mockBatchStandardizeAndMatch).toHaveBeenCalledWith([
+      expect.objectContaining({
+        rawUnit: null,
+        unit: null,
+        zipCode: null,
+        groceryStoreId: null,
+      }),
+    ])
+  })
+
+  it("prefers rawUnit over unit when both are provided", async () => {
+    await POST(
+      makeRequest({
+        standardizedIngredientId: "std_1",
+        store: "aldi",
+        product: { id: "p1", title: "Butter", price: 4.49, rawUnit: "16 oz", unit: "oz" },
+      }) as any
+    )
+
+    expect(mockBatchStandardizeAndMatch).toHaveBeenCalledWith([
+      expect.objectContaining({ rawUnit: "16 oz", unit: "oz" }),
+    ])
   })
 })

--- a/app/api/grocery-search/cache-selection/route.ts
+++ b/app/api/grocery-search/cache-selection/route.ts
@@ -76,28 +76,21 @@ export async function POST(request: NextRequest) {
       },
     ])
 
-    let cachedViaFallback = false
     if (inserted === 0) {
-      const fallback = await ingredientsHistoryDB.insertPrice({
+      // The RPC returned 0 rows — either it errored or all items were skipped/filtered.
+      // A direct insertPrice fallback would create an ingredients_history row with no
+      // product_mapping_id, which get_pricing can't use (it joins through product_mappings).
+      // Return 500 so the caller knows the selection wasn't persisted.
+      console.error("[Cache Selection] batchStandardizeAndMatch returned 0 — selection not cached", {
+        searchTerm,
+        store,
+        productTitle: product.title,
         standardizedIngredientId: resolvedStandardizedIngredientId,
-        store: store.toLowerCase(),
-        productName: product.title,
-        productId: product.id,
-        price: product.price,
-        imageUrl: product.image_url || null,
-        location: product.location || null,
-        zipCode: zipCode || null,
-        groceryStoreId: groceryStoreId || null,
       })
-
-      if (!fallback) {
-        console.error("[Cache Selection] Failed to insert cache entry")
-        return NextResponse.json(
-          { error: "Failed to cache selection" },
-          { status: 500 }
-        )
-      }
-      cachedViaFallback = true
+      return NextResponse.json(
+        { error: "Failed to cache selection" },
+        { status: 500 }
+      )
     }
 
     console.log("[Cache Selection] Successfully cached user selection", {
@@ -106,14 +99,12 @@ export async function POST(request: NextRequest) {
       productTitle: product.title,
       standardizedIngredientId: resolvedStandardizedIngredientId,
       inserted,
-      cachedViaFallback,
     })
 
     return NextResponse.json({
       success: true,
       standardizedIngredientId: resolvedStandardizedIngredientId,
       inserted,
-      cachedViaFallback,
       message: "Selection cached successfully"
     })
   } catch (error) {

--- a/app/store/__tests__/page.test.tsx
+++ b/app/store/__tests__/page.test.tsx
@@ -86,6 +86,7 @@ vi.mock('@/components/store/shopping-receipt-view', () => ({
     onCheckout,
     onRefresh,
     onStoreChange,
+    onRemoveItem,
     onSwapItem,
     loading,
     selectedStore,
@@ -95,10 +96,14 @@ vi.mock('@/components/store/shopping-receipt-view', () => ({
       <span data-testid="receipt-loading">{loading ? 'loading' : 'ready'}</span>
       <span data-testid="selected-store">{selectedStore ?? 'none'}</span>
       <span data-testid="store-count">{storeComparisons.length}</span>
+      <span data-testid="selected-store-item-count">
+        {storeComparisons.find((store: any) => store.store === selectedStore)?.items.length ?? 0}
+      </span>
       <button onClick={onCheckout} data-testid="checkout-btn">Checkout</button>
       <button onClick={onRefresh} data-testid="refresh-btn">Refresh</button>
       <button onClick={() => onStoreChange('Walmart')} data-testid="change-store-btn">Change Store</button>
       <button onClick={() => onStoreChange(null)} data-testid="clear-store-btn">Clear Store</button>
+      <button onClick={() => onRemoveItem('item_1', selectedStore, ['item_1'])} data-testid="remove-btn">Remove</button>
       <button onClick={() => onSwapItem('item_1')} data-testid="swap-btn">Swap</button>
     </div>
   ),
@@ -308,7 +313,7 @@ describe('ShoppingReceiptPage', () => {
       await waitFor(() => {
         expect(mockPerformMassSearch).toHaveBeenCalledWith({
           showCachedFirst: true,
-          skipPricingGaps: false,
+          skipPricingGaps: true,
         })
       })
     })
@@ -347,7 +352,7 @@ describe('ShoppingReceiptPage', () => {
       await waitFor(() => {
         expect(mockPerformMassSearch).toHaveBeenCalledWith({
           showCachedFirst: true,
-          skipPricingGaps: false,
+          skipPricingGaps: true,
         })
       })
     })
@@ -372,6 +377,61 @@ describe('ShoppingReceiptPage', () => {
       await waitFor(() => screen.getByTestId('change-store-btn'))
       await userEvent.click(screen.getByTestId('change-store-btn'))
       expect(mockScrollToStore).toHaveBeenCalledWith(0)
+    })
+
+    it('hides an item only from the active store when remove is clicked', async () => {
+      mockShoppingListWith({ items: sampleItems as any })
+      mockStoreComparisonWith({
+        results: [
+          {
+            store: 'Walmart',
+            groceryStoreId: 'store_1',
+            items: [{
+              shoppingItemId: 'item_1',
+              shoppingItemIds: ['item_1'],
+              productMappingId: 'prod_1',
+              title: 'Apples',
+              price: 0.99,
+              quantity: 1,
+              packagesToBuy: 2,
+              packagePrice: 0.99,
+              unit: 'each',
+            }],
+          },
+          {
+            store: 'Kroger',
+            groceryStoreId: 'store_2',
+            items: [{
+              shoppingItemId: 'item_1',
+              shoppingItemIds: ['item_1'],
+              productMappingId: 'prod_2',
+              title: 'Apples',
+              price: 1.49,
+              quantity: 1,
+              packagesToBuy: 2,
+              packagePrice: 1.49,
+              unit: 'each',
+            }],
+          },
+        ] as any,
+        activeStoreIndex: 0,
+        hasFetched: true,
+      })
+
+      render(<ShoppingReceiptPage />)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('selected-store')).toHaveTextContent('Walmart')
+        expect(screen.getByTestId('selected-store-item-count')).toHaveTextContent('1')
+      })
+
+      await userEvent.click(screen.getByTestId('remove-btn'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('selected-store-item-count')).toHaveTextContent('0')
+      })
+
+      expect(mockRemoveItem).not.toHaveBeenCalled()
     })
   })
 

--- a/app/store/page.tsx
+++ b/app/store/page.tsx
@@ -141,7 +141,7 @@ export default function ShoppingReceiptPage() {
   }, [user])
 
   // Auto-run comparison on load and when non-quantity list inputs change.
-  // First load follows the refresh path; later list edits stay cache-first.
+  // Always cache-only — scraping is triggered explicitly via the update button.
   useEffect(() => {
     if (!mounted || !zipReady || listLoading) return
     if (shoppingList.length === 0) {
@@ -179,21 +179,14 @@ export default function ShoppingReceiptPage() {
     }
 
     let cancelled = false
-    const isInitialLoad = !previousSignatures
 
     const runAutoCompare = async () => {
       previousListSignaturesRef.current = currentSignatures
-      if (isInitialLoad && user?.id) {
-        const locationUpdate = await updateLocation(user.id)
-        if (!locationUpdate.success && locationUpdate.error) {
-          console.warn("[store] updateLocation failed during auto-refresh:", locationUpdate.error)
-        }
-      }
       await saveChanges()
       if (cancelled) return
       await performMassSearch({
         showCachedFirst: true,
-        skipPricingGaps: !isInitialLoad,
+        skipPricingGaps: true,
       })
     }
 
@@ -213,7 +206,6 @@ export default function ShoppingReceiptPage() {
     comparisonFetched,
     saveChanges,
     performMassSearch,
-    user?.id,
   ])
 
   const selectedStore = storeComparisons[carouselIndex]?.store ?? null

--- a/app/store/page.tsx
+++ b/app/store/page.tsx
@@ -13,7 +13,8 @@ import { ShoppingReceiptView } from "@/components/store/shopping-receipt-view"
 import { ItemReplacementModal } from "@/components/store/store-replacement"
 import { MobileQuickAddPanel } from "@/components/store/mobile-quick-add-panel"
 import { standardizedIngredientsDB } from "@/lib/database/standardized-ingredients-db"
-import type { GroceryItem } from "@/lib/types/store"
+import type { GroceryItem, StoreComparison } from "@/lib/types/store"
+import { calcLineTotal } from "@/lib/utils/package-pricing"
 
 const StoreMap = dynamic(
   () => import("@/components/store/store-map").then((mod) => mod.StoreMap),
@@ -56,6 +57,84 @@ function buildListQuantitySignature(items: Array<{ id: string; quantity?: number
     .join("|")
 }
 
+function buildQuantityMap(items: Array<{ id: string; quantity?: number | null }>): Map<string, number> {
+  return new Map(
+    items.map((item) => [
+      item.id,
+      Math.max(1, Number(item.quantity) || 1),
+    ])
+  )
+}
+
+function getEffectiveStoreItemQuantity(
+  item: StoreComparison["items"][number],
+  quantityByItemId: Map<string, number>
+): number {
+  const itemIds = item.shoppingItemIds?.filter(Boolean) || [item.shoppingItemId]
+  let effectiveQty = 0
+
+  itemIds.forEach((id) => {
+    effectiveQty += quantityByItemId.get(id) ?? 0
+  })
+
+  if (effectiveQty <= 0) {
+    effectiveQty = Math.max(1, Number(item.quantity) || 1)
+  }
+
+  return effectiveQty
+}
+
+function getStoreItemLineTotal(
+  item: StoreComparison["items"][number],
+  quantityByItemId: Map<string, number>
+): number {
+  const effectiveQty = getEffectiveStoreItemQuantity(item, quantityByItemId)
+  const lineTotal = calcLineTotal({
+    qty: effectiveQty,
+    packagePrice: item.packagePrice,
+    convertedQty: item.convertedQuantity,
+    conversionError: item.conversionError ?? undefined,
+  })
+
+  return lineTotal ?? (Number(item.price) || 0) * effectiveQty
+}
+
+function filterStoreComparisonsByHiddenItems(
+  storeComparisons: StoreComparison[],
+  hiddenStoreItemIds: Record<string, string[]>,
+  quantityByItemId: Map<string, number>
+): StoreComparison[] {
+  if (storeComparisons.length === 0) return storeComparisons
+
+  const filteredComparisons = storeComparisons.map((store) => {
+    const hiddenIds = new Set(hiddenStoreItemIds[store.store] ?? [])
+    if (hiddenIds.size === 0) return store
+
+    const items = store.items.filter((item) => {
+      const itemIds = item.shoppingItemIds?.filter(Boolean) || [item.shoppingItemId]
+      return !itemIds.some((id) => hiddenIds.has(id))
+    })
+
+    const missingIngredients = store.missingIngredients?.filter((item) => !hiddenIds.has(item.id)) ?? []
+    const total = items.reduce((sum, item) => sum + getStoreItemLineTotal(item, quantityByItemId), 0)
+
+    return {
+      ...store,
+      items,
+      total,
+      missingIngredients,
+      missingCount: missingIngredients.length,
+      missingItems: missingIngredients.length > 0,
+    }
+  })
+
+  const maxTotal = Math.max(...filteredComparisons.map((store) => store.total), 0)
+  return filteredComparisons.map((store) => ({
+    ...store,
+    savings: maxTotal - store.total,
+  }))
+}
+
 export default function ShoppingReceiptPage() {
   const router = useRouter()
   const { user } = useAuth()
@@ -73,6 +152,7 @@ export default function ShoppingReceiptPage() {
     standardizedIngredientId?: string | null
     groceryStoreId?: string | null
   } | null>(null)
+  const [hiddenStoreItemIds, setHiddenStoreItemIds] = useState<Record<string, string[]>>({})
   const previousListSignaturesRef = useRef<{
     identity: string
     quantity: string
@@ -102,6 +182,11 @@ export default function ShoppingReceiptPage() {
   } = useStoreComparison(shoppingList, zipCode, null)
   const listIdentitySignature = useMemo(() => buildListIdentitySignature(shoppingList), [shoppingList])
   const listQuantitySignature = useMemo(() => buildListQuantitySignature(shoppingList), [shoppingList])
+  const quantityByItemId = useMemo(() => buildQuantityMap(shoppingList), [shoppingList])
+  const visibleStoreComparisons = useMemo(
+    () => filterStoreComparisonsByHiddenItems(storeComparisons, hiddenStoreItemIds, quantityByItemId),
+    [storeComparisons, hiddenStoreItemIds, quantityByItemId]
+  )
   const normalizedZipCode = zipCode.trim()
 
   // Hydration handling
@@ -208,29 +293,29 @@ export default function ShoppingReceiptPage() {
     performMassSearch,
   ])
 
-  const selectedStore = storeComparisons[carouselIndex]?.store ?? null
+  const selectedStore = visibleStoreComparisons[carouselIndex]?.store ?? null
 
   const sidebarSelectedStoreIndex = useMemo(() => {
     if (!selectedStore) return 0
-    const index = storeComparisons.findIndex((s) => s.store === selectedStore)
+    const index = visibleStoreComparisons.findIndex((s) => s.store === selectedStore)
     return index >= 0 ? index : 0
-  }, [storeComparisons, selectedStore])
+  }, [selectedStore, visibleStoreComparisons])
 
   const handleSidebarMapStoreSelect = useCallback((storeIndex: number) => {
-    const store = storeComparisons[storeIndex]
+    const store = visibleStoreComparisons[storeIndex]
     if (store) scrollToStore(storeIndex)
-  }, [storeComparisons, scrollToStore])
+  }, [scrollToStore, visibleStoreComparisons])
 
   const handleStoreChange = useCallback((storeName: string | null) => {
     if (!storeName) {
       scrollToStore(0)
       return
     }
-    const nextIndex = storeComparisons.findIndex((store) => store.store === storeName)
+    const nextIndex = visibleStoreComparisons.findIndex((store) => store.store === storeName)
     if (nextIndex >= 0) {
       scrollToStore(nextIndex)
     }
-  }, [scrollToStore, storeComparisons])
+  }, [scrollToStore, visibleStoreComparisons])
 
   const handleRefresh = useCallback(async () => {
     if (user?.id) {
@@ -240,7 +325,7 @@ export default function ShoppingReceiptPage() {
       }
     }
     await saveChanges()
-    await performMassSearch({ showCachedFirst: true, skipPricingGaps: false })
+    await performMassSearch({ showCachedFirst: false, skipPricingGaps: false })
   }, [user?.id, saveChanges, performMassSearch])
 
   const handleMobileAddItem = useCallback(async (name: string) => {
@@ -263,6 +348,26 @@ export default function ShoppingReceiptPage() {
     itemsToRemove.forEach(item => removeItem(item.id))
   }, [shoppingList, removeItem])
 
+  const handleStoreItemRemove = useCallback((
+    itemId: string,
+    storeName?: string | null,
+    itemIds?: string[]
+  ) => {
+    if (!storeName) return
+
+    const idsToHide = itemIds?.length ? itemIds : [itemId]
+    setHiddenStoreItemIds((prev) => {
+      const existing = new Set(prev[storeName] ?? [])
+      idsToHide.forEach((id) => {
+        if (id) existing.add(id)
+      })
+      return {
+        ...prev,
+        [storeName]: Array.from(existing),
+      }
+    })
+  }, [])
+
   const handleSwapRequest = useCallback(async (itemId: string, shoppingListIds?: string[]) => {
     const item = shoppingList.find((shoppingItem) => shoppingItem.id === itemId)
     if (!item) {
@@ -270,13 +375,13 @@ export default function ShoppingReceiptPage() {
       return
     }
 
-    const activeStore = selectedStore || storeComparisons[0]?.store
+    const activeStore = selectedStore || visibleStoreComparisons[0]?.store
     if (!activeStore) {
       toast({ title: "Error", description: "Select a store before replacing items.", variant: "destructive" })
       return
     }
 
-    const activeStoreData = storeComparisons.find((store) => store.store === activeStore)
+    const activeStoreData = visibleStoreComparisons.find((store) => store.store === activeStore)
     const standardizedIngredientId = item.ingredient_id || item.standardizedIngredientId || null
     let replacementSearchTerm = item.name
     const localStandardizedName =
@@ -311,7 +416,7 @@ export default function ShoppingReceiptPage() {
       groceryStoreId: activeStoreData?.groceryStoreId ?? null,
     })
     setReloadModalOpen(true)
-  }, [selectedStore, shoppingList, storeComparisons, toast])
+  }, [selectedStore, shoppingList, toast, visibleStoreComparisons])
 
   const handleSwapConfirmation = useCallback((newItem: GroceryItem) => {
     const primaryId = reloadTarget?.shoppingListIds?.[0] || reloadTarget?.shoppingListId
@@ -335,12 +440,12 @@ export default function ShoppingReceiptPage() {
 
   // Handle checkout
   const handleCheckout = () => {
-    if (!selectedStore && storeComparisons.length > 0) scrollToStore(0)
+    if (!selectedStore && visibleStoreComparisons.length > 0) scrollToStore(0)
 
     // Calculate total price and item count from selected store
     const activeStoreData = selectedStore
-      ? storeComparisons.find((store) => store.store === selectedStore)
-      : storeComparisons[0]
+      ? visibleStoreComparisons.find((store) => store.store === selectedStore)
+      : visibleStoreComparisons[0]
 
     let totalAmount = 0
     let itemCount = 0
@@ -466,12 +571,12 @@ export default function ShoppingReceiptPage() {
             />
 
             {/* Map: desktop sidebar only */}
-            {storeComparisons.length > 0 && (
+            {visibleStoreComparisons.length > 0 && (
               <div className={`hidden lg:block rounded-lg overflow-hidden border ${
                 isDark ? "border-white/10 bg-[#1f1e1a]" : "border-gray-200 bg-white"
               }`} data-tutorial="store-map">
                 <StoreMap
-                  comparisons={storeComparisons}
+                  comparisons={visibleStoreComparisons}
                   onStoreSelected={handleSidebarMapStoreSelect}
                   userPostalCode={zipCode}
                   selectedStoreIndex={sidebarSelectedStoreIndex}
@@ -486,11 +591,11 @@ export default function ShoppingReceiptPage() {
           <div className="order-2 lg:order-1 flex-1 min-h-0 flex flex-col">
             <ShoppingReceiptView
               shoppingList={shoppingList}
-              storeComparisons={storeComparisons}
+              storeComparisons={visibleStoreComparisons}
               selectedStore={selectedStore}
               onStoreChange={handleStoreChange}
               onQuantityChange={updateQuantity}
-              onRemoveItem={removeItem}
+              onRemoveItem={handleStoreItemRemove}
               onSwapItem={handleSwapRequest}
               onCheckout={handleCheckout}
               onRefresh={handleRefresh}

--- a/app/store/page.tsx
+++ b/app/store/page.tsx
@@ -158,6 +158,7 @@ export default function ShoppingReceiptPage() {
     quantity: string
     zipCode: string
   } | null>(null)
+  const refreshInProgressRef = useRef(false)
 
   // Shopping list management
   const {
@@ -318,14 +319,20 @@ export default function ShoppingReceiptPage() {
   }, [scrollToStore, visibleStoreComparisons])
 
   const handleRefresh = useCallback(async () => {
-    if (user?.id) {
-      const locationUpdate = await updateLocation(user.id)
-      if (!locationUpdate.success && locationUpdate.error) {
-        console.warn("[store] updateLocation failed:", locationUpdate.error)
+    if (refreshInProgressRef.current) return
+    refreshInProgressRef.current = true
+    try {
+      if (user?.id) {
+        const locationUpdate = await updateLocation(user.id)
+        if (!locationUpdate.success && locationUpdate.error) {
+          console.warn("[store] updateLocation failed:", locationUpdate.error)
+        }
       }
+      await saveChanges()
+      await performMassSearch({ showCachedFirst: false, skipPricingGaps: false })
+    } finally {
+      refreshInProgressRef.current = false
     }
-    await saveChanges()
-    await performMassSearch({ showCachedFirst: false, skipPricingGaps: false })
   }, [user?.id, saveChanges, performMassSearch])
 
   const handleMobileAddItem = useCallback(async (name: string) => {

--- a/backend/workers/scraper-worker/stores/target.js
+++ b/backend/workers/scraper-worker/stores/target.js
@@ -7,6 +7,42 @@ const { logHttpErrorToDatabase } = require('../utils/db-error-logger');
 const { createResultCache } = require('../utils/result-cache');
 const { withExponentialBackoffRetry } = require('../utils/retry');
 
+// UUID pattern — used to detect grocery_store_id UUIDs vs numeric Target store IDs
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+let _supabase = null;
+function getSupabaseClient() {
+    if (_supabase) return _supabase;
+    const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) return null;
+    const { createClient } = require('@supabase/supabase-js');
+    _supabase = createClient(url, key);
+    return _supabase;
+}
+
+/**
+ * Resolve the numeric Target API store ID from a grocery_stores UUID.
+ * Returns null if the UUID has no target_store_id in its metadata.
+ */
+async function resolveTargetStoreIdFromUuid(groceryStoreId) {
+    if (!groceryStoreId || !UUID_RE.test(groceryStoreId)) return null;
+    const supabase = getSupabaseClient();
+    if (!supabase) return null;
+    try {
+        const { data, error } = await supabase
+            .from('grocery_stores')
+            .select('metadata')
+            .eq('id', groceryStoreId)
+            .single();
+        if (error || !data) return null;
+        const targetStoreId = data.metadata?.target_store_id;
+        return typeof targetStoreId === 'string' && targetStoreId.trim() ? targetStoreId.trim() : null;
+    } catch {
+        return null;
+    }
+}
+
 // Environment variables for configuration
 const TARGET_TIMEOUT_MS = Number(process.env.TARGET_TIMEOUT_MS || 10000);
 const TARGET_MAX_RETRIES = Number(process.env.TARGET_MAX_RETRIES || 2);
@@ -194,21 +230,22 @@ function resolveTargetStoreId(storeMetadata) {
         return null;
     }
 
-    const explicitStoreId =
-        storeMetadata.target_store_id ??
-        storeMetadata.targetStoreId ??
-        storeMetadata.store_id ??
-        storeMetadata.storeId ??
-        storeMetadata.raw?.store_id ??
-        storeMetadata.raw?.storeId ??
-        null;
+    const candidates = [
+        storeMetadata.target_store_id,
+        storeMetadata.targetStoreId,
+        storeMetadata.store_id,
+        storeMetadata.raw?.store_id,
+        storeMetadata.raw?.storeId,
+    ];
 
-    if (explicitStoreId === null || explicitStoreId === undefined) {
-        return null;
+    for (const candidate of candidates) {
+        if (candidate === null || candidate === undefined) continue;
+        const normalized = String(candidate).trim();
+        // Reject UUIDs — those are grocery_store_id values, not Target API store IDs
+        if (normalized.length > 0 && !UUID_RE.test(normalized)) return normalized;
     }
 
-    const normalized = String(explicitStoreId).trim();
-    return normalized.length > 0 ? normalized : null;
+    return null;
 }
 
 function resolveGroceryStoreId(storeMetadata) {
@@ -261,18 +298,18 @@ async function searchTarget(keyword, storeMetadata, zipCode, sortBy = "price") {
                 if (storeId) {
                     storeIdSource = 'db_metadata';
                 }
-                if (!storeId && storeMetadata.id !== undefined && storeMetadata.id !== null) {
-                    log.warn(
-                        `[target] Ignoring generic metadata.id="${storeMetadata.id}" for "${keyword}" (${zipCode}); ` +
-                        `expected target_store_id/store_id to avoid DB-ID collisions`
-                    );
-                }
             } else if (storeMetadata) {
                 storeId = storeMetadata;
                 storeIdSource = 'explicit';
             }
 
-            // If no store data provided, fetch it first
+            // If no numeric store ID yet, look it up from the DB using the grocery_store_id UUID
+            if (!storeId && groceryStoreId) {
+                storeId = await resolveTargetStoreIdFromUuid(groceryStoreId);
+                if (storeId) storeIdSource = 'uuid_lookup';
+            }
+
+            // Final fallback: nearest store by zip
             if (!storeId) {
                 resolvedStoreInfo = await getNearestStore(zipCode);
                 storeId = resolveTargetStoreId(resolvedStoreInfo);

--- a/components/store/__tests__/shopping-receipt-view.test.tsx
+++ b/components/store/__tests__/shopping-receipt-view.test.tsx
@@ -278,7 +278,7 @@ describe("ShoppingReceiptView", () => {
           },
         ]}
         storeComparisons={[]}
-        selectedStore={null}
+        selectedStore="Walmart"
         onStoreChange={vi.fn()}
         onQuantityChange={vi.fn()}
         onRemoveItem={onRemoveItem}
@@ -289,7 +289,7 @@ describe("ShoppingReceiptView", () => {
     fireEvent.click(screen.getByTestId("remove-group:ingredient:std-apples"))
 
     expect(onRemoveItem).toHaveBeenCalledTimes(1)
-    expect(onRemoveItem).toHaveBeenCalledWith("item-a-1")
+    expect(onRemoveItem).toHaveBeenCalledWith("item-a-1", "Walmart", ["item-a-1", "item-a-2"])
   })
 
   it("forwards all source item ids when swapping a merged row", () => {

--- a/components/store/receipt-item.tsx
+++ b/components/store/receipt-item.tsx
@@ -52,11 +52,13 @@ export function ReceiptItem({
   const lineTotal = pricing
     ? (lineTotalFromPkg ?? (Number(pricing.price) || 0) * quantity)
     : null
+  // Ceil when falling back — package counts must be whole numbers even if the
+  // ingredient quantity is fractional (e.g. 1.5 cups when no converted_quantity).
   const packageQuantityDisplay = !isAvailable
     ? "0"
     : adjustedPackagesToBuy !== null
     ? formatMeasure(adjustedPackagesToBuy)
-    : quantityDisplay
+    : String(Math.max(1, Math.ceil(quantity)))
 
   const rawItemName = typeof item.name === "string" ? item.name.trim() : ""
   const displayName = rawItemName || pricing?.originalName?.trim() || pricing?.title?.trim() || "Unnamed item"

--- a/components/store/shopping-receipt-view.tsx
+++ b/components/store/shopping-receipt-view.tsx
@@ -27,7 +27,7 @@ interface ShoppingReceiptViewProps {
   selectedStore: string | null
   onStoreChange: (storeName: string | null) => void
   onQuantityChange: (itemId: string, quantity: number) => void
-  onRemoveItem: (itemId: string) => void
+  onRemoveItem: (itemId: string, storeName?: string | null, itemIds?: string[]) => void
   onSwapItem?: (itemId: string, itemIds?: string[]) => void
   onCheckout?: () => void
   onRefresh?: () => void
@@ -274,8 +274,12 @@ export function ShoppingReceiptView({
   }, [onQuantityChange])
 
   const handleRemoveItem = useCallback((item: ShoppingListDisplayItem) => {
-    onRemoveItem(item.sourceItemIds[0] || item.id)
-  }, [onRemoveItem])
+    onRemoveItem(
+      item.sourceItemIds[0] || item.id,
+      selectedStoreData?.store ?? selectedStore,
+      item.sourceItemIds
+    )
+  }, [onRemoveItem, selectedStore, selectedStoreData])
 
   const handleSwapItem = useCallback((item: ShoppingListDisplayItem) => {
     if (!onSwapItem) return

--- a/components/store/store-replacement.tsx
+++ b/components/store/store-replacement.tsx
@@ -107,53 +107,64 @@ export function ItemReplacementModal({ isOpen, onClose, target, zipCode, onSelec
     try {
       const normalizedTargetStore = normalizeStoreName(target?.store || "")
 
-      // 1. Preferred source: RPC replacement options for this user/store.
-      const replacementOptions =
+      // 1. Fetch RPC options and live scrape results in parallel.
+      // The scraper is always the primary display source; the RPC only provides ingredient IDs.
+      const [replacementOptions, scrapeStoreResults] = await Promise.all([
         userId && target?.store
-          ? await ingredientsRecentDB.getReplacement(userId, target.store, searchTerm)
-          : []
-
-      const rpcIngredientByItemId = new Map<string, string>()
-      const rpcResults: GroceryItem[] = replacementOptions.flatMap((option, optionIdx) => {
-        const offers = Array.isArray(option.offers) ? option.offers : []
-        return offers.map((offer, offerIdx) => {
-          const stableKey = `${target?.store || ""}-${option.ingredient_id}-${offer.product_name || option.canonical_name}-${offer.unit || ""}-${offer.price ?? ""}`
-          const stableId = `replacement-${stableKey.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "") || `${optionIdx}-${offerIdx}`}`
-          rpcIngredientByItemId.set(stableId, option.ingredient_id)
-          return {
-            id: stableId,
-            title: offer.product_name || option.canonical_name || searchTerm,
-            brand: "",
-            price: Number(offer.price) || 0,
-            pricePerUnit:
-              offer.unit_price != null
-                ? `$${Number(offer.unit_price).toFixed(2)}${offer.unit ? `/${offer.unit}` : ""}`
-                : undefined,
-            unit: offer.unit || undefined,
-            image_url: offer.image_url || "",
-            provider: target?.store || "",
-            category: option.category || undefined,
-          } satisfies GroceryItem
-        })
-      })
-
-      // 2. Fallback source: live scrape if RPC has no candidates.
-      const fallbackResults = rpcResults.length > 0
-        ? rpcResults
-        : (await searchGroceryStores(
+          ? ingredientsRecentDB.getReplacement(userId, target.store, searchTerm)
+          : Promise.resolve([]),
+        searchGroceryStores(
           searchTerm,
           zipCode,
           target?.store,
           true,
           target?.standardizedIngredientId || null
-        ))
-          .filter((storeResult) => normalizeStoreName(storeResult.store) === normalizedTargetStore)
-          .flatMap((storeResult) =>
-            (storeResult.items || []).map((item) => ({
-              ...item,
-              provider: target?.store || item.provider || "",
-            }))
-          )
+        ),
+      ])
+
+      const rpcIngredientByItemId = new Map<string, string>()
+      replacementOptions.forEach((option, optionIdx) => {
+        const offers = Array.isArray(option.offers) ? option.offers : []
+        offers.forEach((offer, offerIdx) => {
+          const stableKey = `${target?.store || ""}-${option.ingredient_id}-${offer.product_name || option.canonical_name}-${offer.unit || ""}-${offer.price ?? ""}`
+          const stableId = `replacement-${stableKey.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "") || `${optionIdx}-${offerIdx}`}`
+          rpcIngredientByItemId.set(stableId, option.ingredient_id)
+        })
+      })
+
+      // 2. Use live scrape results; fall back to RPC-only results if scraper returned nothing.
+      const scrapeResults = scrapeStoreResults
+        .filter((storeResult) => normalizeStoreName(storeResult.store) === normalizedTargetStore)
+        .flatMap((storeResult) =>
+          (storeResult.items || []).map((item) => ({
+            ...item,
+            provider: target?.store || item.provider || "",
+          }))
+        )
+
+      const fallbackResults = scrapeResults.length > 0
+        ? scrapeResults
+        : replacementOptions.flatMap((option, optionIdx) => {
+            const offers = Array.isArray(option.offers) ? option.offers : []
+            return offers.map((offer, offerIdx) => {
+              const stableKey = `${target?.store || ""}-${option.ingredient_id}-${offer.product_name || option.canonical_name}-${offer.unit || ""}-${offer.price ?? ""}`
+              const stableId = `replacement-${stableKey.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "") || `${optionIdx}-${offerIdx}`}`
+              return {
+                id: stableId,
+                title: offer.product_name || option.canonical_name || searchTerm,
+                brand: "",
+                price: Number(offer.price) || 0,
+                pricePerUnit:
+                  offer.unit_price != null
+                    ? `$${Number(offer.unit_price).toFixed(2)}${offer.unit ? `/${offer.unit}` : ""}`
+                    : undefined,
+                unit: offer.unit || undefined,
+                image_url: offer.image_url || "",
+                provider: target?.store || "",
+                category: option.category || undefined,
+              } satisfies GroceryItem
+            })
+          })
 
       const flatResults = fallbackResults.filter((item) => {
         const itemProvider = normalizeStoreName(item.provider || target?.store || "")
@@ -190,8 +201,8 @@ export function ItemReplacementModal({ isOpen, onClose, target, zipCode, onSelec
         price: item.price,
         productName: item.title,
         productId: item.id,
-        rawUnit: item.rawUnit ?? item.unit ?? null,
-        unit: item.unit ?? item.rawUnit ?? null,
+        rawUnit: (item as any).rawUnit ?? item.unit ?? null,
+        unit: item.unit ?? (item as any).rawUnit ?? null,
         zipCode: zipCode || null,
         groceryStoreId: target?.groceryStoreId ?? null,
       }))

--- a/hooks/shopping/__tests__/use-store-comparison.test.ts
+++ b/hooks/shopping/__tests__/use-store-comparison.test.ts
@@ -1,0 +1,448 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { http, HttpResponse } from "msw"
+import { server } from "@/test/mocks/server"
+
+// ── Hoisted mocks (must precede all imports that reference them) ──────────────
+
+const {
+  mockGetPricingForUser,
+  mockGetPricingGaps,
+  mockBatchInsertPricesRpc,
+  mockBatchInsertPrices,
+  mockSearchGroceryStores,
+  mockToast,
+} = vi.hoisted(() => ({
+  mockGetPricingForUser: vi.fn(),
+  mockGetPricingGaps: vi.fn(),
+  mockBatchInsertPricesRpc: vi.fn(),
+  mockBatchInsertPrices: vi.fn(),
+  mockSearchGroceryStores: vi.fn(),
+  mockToast: vi.fn(),
+}))
+
+vi.mock("@/lib/database/ingredients-db", () => ({
+  ingredientsRecentDB: {
+    getPricingForUser: mockGetPricingForUser,
+    getPricingGaps: mockGetPricingGaps,
+  },
+  ingredientsHistoryDB: {
+    batchInsertPricesRpc: mockBatchInsertPricesRpc,
+    batchInsertPrices: mockBatchInsertPrices,
+  },
+  normalizeStoreName: (s: string) =>
+    s.toLowerCase().replace(/\s+/g, "").replace(/[']/g, "").trim(),
+}))
+
+vi.mock("@/backend/orchestrators/frontend-scraper-pipeline/runner", () => ({
+  searchGroceryStores: mockSearchGroceryStores,
+}))
+
+vi.mock("@/hooks/ui/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}))
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ user: { id: "user-1" } }),
+}))
+
+import { useStoreComparison } from "../use-store-comparison"
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeItem(id: string, name: string, ingredientId?: string) {
+  return {
+    id,
+    name,
+    quantity: 1,
+    unit: null,
+    ingredient_id: ingredientId ?? null,
+    standardizedIngredientId: ingredientId ?? null,
+    user_id: "user-1",
+    checked: false,
+    source_type: "manual" as const,
+    recipe_id: null,
+    recipe_ingredient_id: null,
+  } as any
+}
+
+function makeScraperResult(store: string, items: Array<{ id: string; title: string; price: number }>) {
+  return {
+    store,
+    items: items.map(i => ({ ...i, image_url: "", provider: store, rawUnit: undefined })),
+  }
+}
+
+const storeMetadataHandler = http.get("/api/user-store-metadata", () =>
+  HttpResponse.json({ metadata: [] })
+)
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("useStoreComparison › performMassSearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetPricingForUser.mockResolvedValue([])
+    mockGetPricingGaps.mockResolvedValue([])
+    mockBatchInsertPricesRpc.mockResolvedValue(1)
+    mockSearchGroceryStores.mockResolvedValue([])
+    server.use(storeMetadataHandler)
+  })
+
+  // ── Guard conditions ────────────────────────────────────────────────────────
+
+  describe("guard conditions", () => {
+    it("shows an Empty List toast and returns early when shoppingList is empty", async () => {
+      const { result } = renderHook(() => useStoreComparison([], "90210", null))
+
+      await act(async () => {
+        await result.current.performMassSearch()
+      })
+
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Empty List" })
+      )
+      expect(mockGetPricingForUser).not.toHaveBeenCalled()
+    })
+
+    it("shows a Zip Code Required toast and returns early when zipCode is blank", async () => {
+      const { result } = renderHook(() =>
+        useStoreComparison([makeItem("1", "milk")], "", null)
+      )
+
+      await act(async () => {
+        await result.current.performMassSearch()
+      })
+
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Zip Code Required" })
+      )
+      expect(mockGetPricingForUser).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── showCachedFirst ─────────────────────────────────────────────────────────
+
+  describe("showCachedFirst", () => {
+    it("reads cached pricing and marks hasFetched before gap hydration runs", async () => {
+      const cached = [
+        { standardized_ingredient_id: "ing-1", item_ids: ["item-1"], total_amount: 1, offers: [] },
+      ]
+      mockGetPricingForUser.mockResolvedValue(cached)
+
+      const { result } = renderHook(() =>
+        useStoreComparison([makeItem("item-1", "milk", "ing-1")], "90210", null)
+      )
+
+      await act(async () => {
+        await result.current.performMassSearch({ showCachedFirst: true, skipPricingGaps: true })
+      })
+
+      expect(mockGetPricingForUser).toHaveBeenCalledWith("user-1")
+      expect(result.current.hasFetched).toBe(true)
+    })
+
+    it("calls getPricingForUser exactly once when showCachedFirst is false (no initial read)", async () => {
+      const { result } = renderHook(() =>
+        useStoreComparison([makeItem("1", "milk")], "90210", null)
+      )
+
+      await act(async () => {
+        await result.current.performMassSearch({ showCachedFirst: false, skipPricingGaps: true })
+      })
+
+      // Only the final read, not a pre-render cache pass
+      expect(mockGetPricingForUser).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ── Gap hydration ───────────────────────────────────────────────────────────
+
+  describe("gap hydration (skipPricingGaps: false)", () => {
+    it("skips getPricingGaps and batchInsertPricesRpc when skipPricingGaps is true", async () => {
+      const { result } = renderHook(() =>
+        useStoreComparison([makeItem("1", "milk", "ing-1")], "90210", null)
+      )
+
+      await act(async () => {
+        await result.current.performMassSearch({ showCachedFirst: false, skipPricingGaps: true })
+      })
+
+      expect(mockGetPricingGaps).not.toHaveBeenCalled()
+      expect(mockBatchInsertPricesRpc).not.toHaveBeenCalled()
+    })
+
+    it("calls getPricingGaps but skips scraping when there are no gaps", async () => {
+      mockGetPricingGaps.mockResolvedValue([])
+
+      const { result } = renderHook(() =>
+        useStoreComparison([makeItem("1", "milk", "ing-1")], "90210", null)
+      )
+
+      await act(async () => {
+        await result.current.performMassSearch({ showCachedFirst: false, skipPricingGaps: false })
+      })
+
+      expect(mockGetPricingGaps).toHaveBeenCalledWith("user-1")
+      expect(mockSearchGroceryStores).not.toHaveBeenCalled()
+      expect(mockBatchInsertPricesRpc).not.toHaveBeenCalled()
+      // Final pricing read still happens
+      expect(mockGetPricingForUser).toHaveBeenCalledTimes(1)
+    })
+
+    it("scrapes each unique gap ingredient and inserts results via batchInsertPricesRpc", async () => {
+      mockGetPricingGaps.mockResolvedValue([
+        {
+          store: "target",
+          grocery_store_id: "store-uuid-1",
+          zip_code: "90210",
+          ingredients: [
+            { id: "ing-1", name: "milk" },
+            { id: "ing-2", name: "eggs" },
+          ],
+        },
+      ])
+      mockSearchGroceryStores.mockResolvedValue([
+        makeScraperResult("target", [{ id: "p1", title: "Whole Milk", price: 3.99 }]),
+      ])
+
+      const { result } = renderHook(() =>
+        useStoreComparison(
+          [makeItem("1", "milk", "ing-1"), makeItem("2", "eggs", "ing-2")],
+          "90210",
+          null
+        )
+      )
+
+      await act(async () => {
+        await result.current.performMassSearch({ showCachedFirst: false, skipPricingGaps: false })
+      })
+
+      expect(mockSearchGroceryStores).toHaveBeenCalledTimes(2)
+      expect(mockSearchGroceryStores).toHaveBeenCalledWith("milk", "90210", "target", true, "ing-1")
+      expect(mockSearchGroceryStores).toHaveBeenCalledWith("eggs", "90210", "target", true, "ing-2")
+      expect(mockBatchInsertPricesRpc).toHaveBeenCalledOnce()
+    })
+
+    it("calls getPricingForUser after gap hydration to fetch freshly-written prices", async () => {
+      mockGetPricingGaps.mockResolvedValue([
+        {
+          store: "target",
+          grocery_store_id: "store-1",
+          zip_code: "90210",
+          ingredients: [{ id: "ing-1", name: "milk" }],
+        },
+      ])
+      mockSearchGroceryStores.mockResolvedValue([
+        makeScraperResult("target", [{ id: "p1", title: "Milk", price: 3.49 }]),
+      ])
+
+      const { result } = renderHook(() =>
+        useStoreComparison([makeItem("1", "milk", "ing-1")], "90210", null)
+      )
+
+      await act(async () => {
+        await result.current.performMassSearch({ showCachedFirst: false, skipPricingGaps: false })
+      })
+
+      // getPricingForUser must run AFTER batchInsertPricesRpc to read the fresh data
+      const batchCallOrder = mockBatchInsertPricesRpc.mock.invocationCallOrder[0]
+      const pricingCallOrder = mockGetPricingForUser.mock.invocationCallOrder[0]
+      expect(batchCallOrder).toBeLessThan(pricingCallOrder)
+    })
+
+    it("calls batchInsertPricesRpc exactly once — the dead batchInsertPrices fallback is removed", async () => {
+      mockGetPricingGaps.mockResolvedValue([
+        {
+          store: "target",
+          grocery_store_id: "store-1",
+          zip_code: "90210",
+          ingredients: [{ id: "ing-1", name: "milk" }],
+        },
+      ])
+      mockSearchGroceryStores.mockResolvedValue([
+        makeScraperResult("target", [{ id: "p1", title: "Milk", price: 3.49 }]),
+      ])
+      mockBatchInsertPricesRpc.mockResolvedValue(0) // simulate RPC returning 0
+
+      const { result } = renderHook(() =>
+        useStoreComparison([makeItem("1", "milk", "ing-1")], "90210", null)
+      )
+
+      await act(async () => {
+        await result.current.performMassSearch({ showCachedFirst: false, skipPricingGaps: false })
+      })
+
+      expect(mockBatchInsertPricesRpc).toHaveBeenCalledOnce()
+      // batchInsertPrices internally calls batchInsertPricesRpc — calling it as a
+      // fallback would just re-issue the same failing RPC. It must not be called.
+      expect(mockBatchInsertPrices).not.toHaveBeenCalled()
+    })
+
+    it("deduplicates ingredients within a gap before scraping", async () => {
+      mockGetPricingGaps.mockResolvedValue([
+        {
+          store: "kroger",
+          grocery_store_id: "store-1",
+          zip_code: "90210",
+          // Same ingredient id twice — must only scrape once
+          ingredients: [
+            { id: "ing-1", name: "milk" },
+            { id: "ing-1", name: "milk" },
+          ],
+        },
+      ])
+      mockSearchGroceryStores.mockResolvedValue([])
+
+      const { result } = renderHook(() =>
+        useStoreComparison([makeItem("1", "milk", "ing-1")], "90210", null)
+      )
+
+      await act(async () => {
+        await result.current.performMassSearch({ showCachedFirst: false, skipPricingGaps: false })
+      })
+
+      expect(mockSearchGroceryStores).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ── Generation / isStale guards ─────────────────────────────────────────────
+
+  describe("generation / isStale race-condition guards", () => {
+    it("bails out after getPricingGaps when a concurrent search has superseded it", async () => {
+      let resolveFirstGaps!: (v: any[]) => void
+      const firstGapsDeferred = new Promise<any[]>(r => { resolveFirstGaps = r })
+
+      let callCount = 0
+      mockGetPricingGaps.mockImplementation(() => {
+        callCount++
+        return callCount === 1 ? firstGapsDeferred : Promise.resolve([])
+      })
+
+      const { result } = renderHook(() =>
+        useStoreComparison([makeItem("1", "milk", "ing-1")], "90210", null)
+      )
+
+      // Start search 1 (will pause at the deferred getPricingGaps)
+      const search1 = result.current.performMassSearch({
+        showCachedFirst: false,
+        skipPricingGaps: false,
+      })
+
+      // Start search 2 immediately — increments the generation counter, making search 1 stale
+      await act(async () => {
+        await result.current.performMassSearch({
+          showCachedFirst: false,
+          skipPricingGaps: false,
+        })
+      })
+
+      // Release search 1's getPricingGaps with a gap that would normally trigger scraping
+      act(() => {
+        resolveFirstGaps([
+          {
+            store: "target",
+            grocery_store_id: "g1",
+            zip_code: "90210",
+            ingredients: [{ id: "ing-1", name: "milk" }],
+          },
+        ])
+      })
+      await act(async () => { await search1 })
+
+      // Search 1 detected isStale() after getPricingGaps and bailed early —
+      // the scraper and batch insert must not have been called.
+      expect(mockSearchGroceryStores).not.toHaveBeenCalled()
+      expect(mockBatchInsertPricesRpc).not.toHaveBeenCalled()
+    })
+
+    it("does not render results from a superseded search after getPricingForUser", async () => {
+      const staleOffers = [{ store: "stale-store", total_price: 1.00, product_name: "Stale Milk" }]
+      const freshOffers = [{ store: "fresh-store", total_price: 2.00, product_name: "Fresh Milk" }]
+
+      let resolveFirstPricing!: (v: any[]) => void
+      const firstPricingDeferred = new Promise<any[]>(r => { resolveFirstPricing = r })
+
+      let callCount = 0
+      mockGetPricingForUser.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) return firstPricingDeferred
+        return Promise.resolve([
+          {
+            standardized_ingredient_id: "ing-fresh",
+            item_ids: ["item-1"],
+            total_amount: 1,
+            offers: freshOffers,
+          },
+        ])
+      })
+
+      const { result } = renderHook(() =>
+        useStoreComparison([makeItem("item-1", "milk", "ing-fresh")], "90210", null)
+      )
+
+      // Start search 1 (pauses at getPricingForUser)
+      const search1 = result.current.performMassSearch({ showCachedFirst: true, skipPricingGaps: true })
+
+      // Start search 2 (becomes the authoritative generation)
+      await act(async () => {
+        await result.current.performMassSearch({ showCachedFirst: true, skipPricingGaps: true })
+      })
+
+      // Release search 1 with stale data — the isStale() guard must discard it
+      resolveFirstPricing([
+        {
+          standardized_ingredient_id: "ing-stale",
+          item_ids: ["item-1"],
+          total_amount: 1,
+          offers: staleOffers,
+        },
+      ])
+      await act(async () => { await search1 })
+
+      // Results must reflect search 2 (fresh) not search 1 (stale)
+      const storeNames = result.current.results.map(r => r.store)
+      expect(storeNames).not.toContain("stale-store")
+    })
+  })
+
+  // ── Loading / hasFetched lifecycle ──────────────────────────────────────────
+
+  describe("loading and hasFetched lifecycle", () => {
+    it("is not loading before any search is triggered", () => {
+      const { result } = renderHook(() =>
+        useStoreComparison([makeItem("1", "milk")], "90210", null)
+      )
+      expect(result.current.loading).toBe(false)
+      expect(result.current.hasFetched).toBe(false)
+    })
+
+    it("sets loading=false and hasFetched=true after a successful search", async () => {
+      const { result } = renderHook(() =>
+        useStoreComparison([makeItem("1", "milk")], "90210", null)
+      )
+
+      await act(async () => {
+        await result.current.performMassSearch({ showCachedFirst: true, skipPricingGaps: true })
+      })
+
+      expect(result.current.loading).toBe(false)
+      expect(result.current.hasFetched).toBe(true)
+    })
+
+    it("sets loading=false and hasFetched=true even when getPricingForUser throws", async () => {
+      mockGetPricingForUser.mockRejectedValue(new Error("DB error"))
+
+      const { result } = renderHook(() =>
+        useStoreComparison([makeItem("1", "milk")], "90210", null)
+      )
+
+      await act(async () => {
+        await result.current.performMassSearch({ showCachedFirst: true, skipPricingGaps: true })
+      })
+
+      expect(result.current.loading).toBe(false)
+      expect(result.current.hasFetched).toBe(true)
+    })
+  })
+})

--- a/hooks/shopping/use-store-comparison.ts
+++ b/hooks/shopping/use-store-comparison.ts
@@ -203,10 +203,8 @@ async function hydratePricingGaps(
 
   console.log("[useStoreComparison] Batch insert payload", { payloadCount: payloads.length })
 
-  let count = await ingredientsHistoryDB.batchInsertPricesRpc(payloads)
-  if (count === 0) {
-    count = await ingredientsHistoryDB.batchInsertPrices(payloads)
-  }
+  // batchInsertPrices internally calls batchInsertPricesRpc — no separate fallback needed.
+  const count = await ingredientsHistoryDB.batchInsertPricesRpc(payloads)
 
   if (count === 0) {
     console.warn("[useStoreComparison] Failed to backfill pricing gaps")
@@ -545,6 +543,8 @@ export function useStoreComparison(
       // ----- Fill cache gaps -----
       if (user && !options?.skipPricingGaps) {
         const pricingGaps = await ingredientsRecentDB.getPricingGaps(user.id)
+        // A newer search may have started while we were waiting for getPricingGaps.
+        if (isStale()) return
         if (pricingGaps.length > 0) {
           console.warn("[useStoreComparison] Filling pricing gaps", { gaps: pricingGaps.length })
           console.log("[useStoreComparison] Pricing gaps payload", pricingGaps)
@@ -554,6 +554,8 @@ export function useStoreComparison(
             gaps: pricingGaps.length,
             inserted,
           })
+          // A newer search may have started while we were scraping (hydration can be slow).
+          if (isStale()) return
         }
       }
 

--- a/lib/database/grocery-stores-db.ts
+++ b/lib/database/grocery-stores-db.ts
@@ -51,10 +51,14 @@ class GroceryStoresTable extends BaseTable<
       store_enum: dbItem.store_enum,
       name: dbItem.name,
       address: dbItem.address,
+      city: dbItem.city ?? null,
+      state: dbItem.state ?? null,
       zip_code: dbItem.zip_code,
       geom: dbItem.geom,
       is_active: dbItem.is_active,
       created_at: dbItem.created_at,
+      failure_count: dbItem.failure_count ?? null,
+      metadata: dbItem.metadata ?? null,
     }
   }
 

--- a/lib/database/ingredients-db.ts
+++ b/lib/database/ingredients-db.ts
@@ -124,6 +124,12 @@ class IngredientsHistoryTable extends BaseTable<
     }
   }
 
+  /**
+   * @deprecated Prefer batchInsertPricesRpc or batchStandardizeAndMatch directly.
+   * This method normalizes a legacy payload shape and forwards to batchInsertPricesRpc.
+   * Fields not accepted by the RPC (standardizedIngredientId, productMappingId, location)
+   * are silently dropped; the DB resolves the ingredient ID from the product name.
+   */
   async batchInsertPrices(
     items: Array<{
       standardizedIngredientId: string
@@ -144,8 +150,6 @@ class IngredientsHistoryTable extends BaseTable<
     try {
       if (items.length === 0) return 0
 
-      // Live schema writes to ingredients_history are handled via RPC.
-      // Normalize legacy payloads into fn_bulk_insert_ingredient_history input.
       const rpcItems = items.map((item) => ({
         store: item.store,
         price: item.price,

--- a/lib/store/store-metadata.ts
+++ b/lib/store/store-metadata.ts
@@ -70,7 +70,6 @@ export function buildStoreMetadataFromRows(
 export function buildStoreMetadataFromStoreData(
   stores: Map<string, {
     id?: string
-    storeId?: string
     grocery_store_id?: string
     zip_code?: string | null
     latitude?: number | null
@@ -85,8 +84,8 @@ export function buildStoreMetadataFromStoreData(
     const longitude = toNullableNumber(store.longitude)
     const distanceMiles = toNullableNumber(store.distance_miles)
     metadata.set(key, {
-      storeId: store.storeId ?? store.id,
-      grocery_store_id: store.grocery_store_id ?? store.storeId ?? store.id,
+      storeId: store.grocery_store_id ?? store.id,
+      grocery_store_id: store.grocery_store_id ?? store.id,
       zipCode: store.zip_code ?? null,
       latitude,
       longitude,

--- a/lib/store/user-preferred-stores.ts
+++ b/lib/store/user-preferred-stores.ts
@@ -92,8 +92,8 @@ async function hydrateMissingStoresFromZip(
           id: store.id,
           name: store.name,
           address: store.address,
-          city: null, // Not in current schema, would need to parse from address
-          state: null,
+          city: store.city ?? null,
+          state: store.state ?? null,
           zip_code: store.zip_code,
           store_enum: store.store_enum,
           grocery_store_id: store.id,
@@ -139,11 +139,11 @@ async function fetchUserPreferredStoresUncached(
             id: row.store_id,
             name: row.store_name,
             address: row.address,
-            city: null, // RPC doesn't return city separately
-            state: null, // RPC doesn't return state separately
+            city: null,
+            state: null,
             zip_code: row.zip_code,
             store_enum: row.store_brand,
-            grocery_store_id: row.grocery_store_id ?? row.store_id,
+            grocery_store_id: (row as any).grocery_store_id ?? row.store_id,
             storeId: row.store_id,
             latitude: latitude ?? undefined,
             longitude: longitude ?? undefined,


### PR DESCRIPTION
## What changed
- Reworked store browsing and comparison behavior across the store, recipes, meal planner, and grocery search flows.
- Added and expanded unit coverage around cache selection, store comparison, and store/shopping UI behavior.
- Updated target-store scraping and related store metadata handling to support the new flow.

## Why
- The store experience needed better separation between store-specific lists and more reliable comparison behavior when shopping and replacing items.
- The associated UI and worker paths were updated together so the app and scraper stay aligned.

## Validation
- `pnpm vitest run app/api/grocery-search/cache-selection/__tests__/route.test.ts hooks/shopping/__tests__/use-store-comparison.test.ts app/store/__tests__/page.test.tsx components/store/__tests__/shopping-receipt-view.test.tsx`
- Result: 4 test files passed, 61 tests passed