### PR TITLE
fix(scraper/99ranch): browser headers + cookie warmup + retry on 101002

### DIFF
--- a/backend/workers/scraper-worker/stores/99ranch.js
+++ b/backend/workers/scraper-worker/stores/99ranch.js
@@ -11,6 +11,8 @@ const log = createScraperLogger('99ranch');
 
 const DEFAULT_BATCH_CONCURRENCY = Number(process.env.RANCH99_BATCH_CONCURRENCY || 3);
 const MAX_BATCH_CONCURRENCY = 8;
+const SEARCH_RETRY_ATTEMPTS = Number(process.env.RANCH99_SEARCH_RETRIES || 2);
+const SEARCH_RETRY_BASE_MS = Number(process.env.RANCH99_SEARCH_RETRY_BASE_MS || 400);
 
 const { enforceRateLimit } = createRateLimiter({
     requestsPerSecond: Number(process.env.RANCH99_REQUESTS_PER_SECOND || 2),
@@ -20,40 +22,94 @@ const { enforceRateLimit } = createRateLimiter({
     label: '[99ranch]',
 });
 
-// Utility function to handle timeouts
+// Browser-grade headers. 99 Ranch sits behind Cloudflare; missing sec-ch-* +
+// sec-fetch-* headers escalates to bot challenges that surface as opaque
+// upstream "TimeOut Error" (code 101002) responses on the search endpoint.
+const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36';
+const BROWSER_HEADERS = {
+    'User-Agent': CHROME_UA,
+    'Accept-Language': 'en-US,en;q=0.9',
+    'sec-ch-ua': '"Chromium";v="135", "Not-A.Brand";v="8", "Google Chrome";v="135"',
+    'sec-ch-ua-mobile': '?0',
+    'sec-ch-ua-platform': '"Windows"',
+    'Upgrade-Insecure-Requests': '1',
+};
+const API_HEADERS = {
+    ...BROWSER_HEADERS,
+    'accept': 'application/json',
+    'content-type': 'application/json',
+    'lang': 'en_US',
+    'time-zone': 'America/Los_Angeles',
+    'sec-fetch-site': 'same-origin',
+    'sec-fetch-mode': 'cors',
+    'sec-fetch-dest': 'empty',
+    'origin': 'https://www.99ranch.com',
+};
+
 const withTimeout = (promise, ms) => withScraperTimeout(promise, ms);
+
+// Warm-up cookie jar shared across calls in the same process. Cloudflare
+// __cf_bm cookies are short-lived (~30 min) which is fine for our cadence.
+const cookieJar = {
+    cookieHeader: '',
+    fetchedAt: 0,
+};
+
+function parseSetCookieHeader(setCookieHeader) {
+    if (!setCookieHeader) return [];
+    const cookies = Array.isArray(setCookieHeader) ? setCookieHeader : [setCookieHeader];
+    return cookies.map((c) => c.split(';')[0]).filter(Boolean);
+}
+
+async function warmCookieJar() {
+    if (cookieJar.cookieHeader && Date.now() - cookieJar.fetchedAt < 1000 * 60 * 20) {
+        return cookieJar.cookieHeader;
+    }
+    try {
+        await enforceRateLimit();
+        const res = await axios.get('https://www.99ranch.com/en_US', {
+            headers: BROWSER_HEADERS,
+            timeout: REQUEST_TIMEOUT_MS,
+            validateStatus: () => true,
+        });
+        const setCookies = parseSetCookieHeader(res.headers?.['set-cookie']);
+        cookieJar.cookieHeader = setCookies.join('; ');
+        cookieJar.fetchedAt = Date.now();
+        return cookieJar.cookieHeader;
+    } catch (error) {
+        log.warn('99 Ranch cookie warm-up failed:', error.message);
+        return cookieJar.cookieHeader || '';
+    }
+}
+
+function mergeCookies(...cookieStrings) {
+    return cookieStrings.filter(Boolean).join('; ');
+}
 
 async function getNearestStore(zip) {
     try {
         await enforceRateLimit();
+        const warmCookies = await warmCookieJar();
         const res = await withTimeout(axios.post(
-            "https://www.99ranch.com/be-api/store/web/nearby/stores",
-            {
-                zipCode: zip,
-                pageSize: 1,
-                pageNum: 1,
-                type: 1,
-                source: "WEB",
-                within: null
-            },
+            'https://www.99ranch.com/be-api/store/web/nearby/stores',
+            { zipCode: zip, pageSize: 1, pageNum: 1, type: 1, source: 'WEB', within: null },
             {
                 headers: {
-                    "accept": "application/json",
-                    "content-type": "application/json",
-                    "lang": "en_US",
-                    "time-zone": "America/Los_Angeles",
-                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
-                    "Accept-Language": "en-US,en;q=0.9",
-                    "Accept-Encoding": "gzip, deflate, br",
-                    "Connection": "keep-alive"
-                }
+                    ...API_HEADERS,
+                    'referer': 'https://www.99ranch.com/store-locator',
+                    ...(warmCookies ? { Cookie: warmCookies } : {}),
+                },
+                validateStatus: () => true,
             }
         ), REQUEST_TIMEOUT_MS);
 
-        const stores = res.data?.data?.records || [];
-        if (!stores.length) {
+        if (res.status !== 200 || res.data?.code !== 0) {
+            log.warn(`99 Ranch nearby-stores non-OK: status=${res.status} code=${res.data?.code} message=${res.data?.message}`);
             return null;
         }
+
+        const stores = res.data?.data?.records || [];
+        if (!stores.length) return null;
 
         const store = stores[0];
         return {
@@ -68,110 +124,100 @@ async function getNearestStore(zip) {
             longitude: store.longitude,
         };
     } catch (error) {
-        log.error("Error getting nearest 99 Ranch store:", error.message);
+        log.error('Error getting nearest 99 Ranch store:', error.message);
         return null;
     }
 }
 
-const buildCache = {
-    id: null,
-    fetchedAt: 0,
-};
+async function searchProductsOnce(store, keyword, zipCode) {
+    if (!store?.id) return { ok: false, list: [], reason: 'no_store' };
 
-async function getBuildId() {
-    if (buildCache.id && Date.now() - buildCache.fetchedAt < 1000 * 60 * 60) {
-        return buildCache.id;
-    }
+    const warmCookies = await warmCookieJar();
+    const sessionCookies = mergeCookies(
+        warmCookies,
+        `storeid=${store.id}`,
+        `zipcode=${zipCode}`,
+        'deliveryType=1'
+    );
 
-    try {
-        await enforceRateLimit();
-        const res = await axios.get("https://www.99ranch.com/en_US", {
-            headers: {
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
+    await enforceRateLimit();
+    const res = await withTimeout(
+        axios.post(
+            'https://www.99ranch.com/be-api/search/web/products',
+            { page: 1, pageSize: 28, keyword, availability: 1 },
+            {
+                headers: {
+                    ...API_HEADERS,
+                    'storeid': String(store.id),
+                    'deliveryType': '1',
+                    'referer': `https://www.99ranch.com/search?keyword=${encodeURIComponent(keyword)}`,
+                    'Cache-Control': 'no-cache',
+                    'Pragma': 'no-cache',
+                    Cookie: sessionCookies,
+                },
+                validateStatus: () => true,
             },
-        });
+        ),
+        REQUEST_TIMEOUT_MS,
+    );
 
-        const match = typeof res.data === "string" ? res.data.match(/"buildId":"([^"]+)"/) : null;
-        if (!match) {
-            throw new Error("Unable to extract Next.js build ID");
-        }
-
-        buildCache.id = match[1];
-        buildCache.fetchedAt = Date.now();
-        return buildCache.id;
-    } catch (error) {
-        log.error("Error fetching 99 Ranch build ID:", error.message);
-        throw error;
+    if (res.status !== 200) {
+        return { ok: false, list: [], reason: `http_${res.status}`, status: res.status };
     }
+    const code = res.data?.code;
+    if (code !== 0) {
+        return { ok: false, list: [], reason: `api_code_${code}`, message: res.data?.message };
+    }
+    return { ok: true, list: res.data?.data?.list || [] };
 }
 
 async function searchProducts(store, keyword, zipCode) {
-    if (!store?.id) {
-        return [];
-    }
-
-    const cookie = [`storeid=${store.id}`, `zipcode=${zipCode}`, "deliveryType=1"].join("; ");
-
-    try {
-        await enforceRateLimit();
-        const res = await withTimeout(
-            axios.post(
-                "https://www.99ranch.com/be-api/search/web/products",
-                {
-                    page: 1,
-                    pageSize: 28,
-                    keyword,
-                    availability: 1,
-                },
-                {
-                    headers: {
-                        "accept": "application/json",
-                        "content-type": "application/json",
-                        "storeid": store.id,
-                        "deliveryType": "1",
-                        "time-zone": "America/Los_Angeles",
-                        "lang": "en_US",
-                        "origin": "https://www.99ranch.com",
-                        "referer": `https://www.99ranch.com/search?keyword=${encodeURIComponent(keyword)}`,
-                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
-                        "Accept-Language": "en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7",
-                        "Cache-Control": "no-cache",
-                        "Pragma": "no-cache",
-                        Cookie: cookie,
-                    },
-                },
-            ),
-            REQUEST_TIMEOUT_MS,
-        );
-
-        return res.data?.data?.list || [];
-    } catch (error) {
-        log.error("Error searching 99 Ranch products via API:", error.message);
-        if (error.response?.status) {
-            await logHttpErrorToDatabase({ storeEnum: '99ranch', zipCode, storeId: String(store?.id), ingredientName: keyword, httpStatus: error.response.status, errorMessage: error.message });
+    if (!store?.id) return [];
+    let lastReason = null;
+    for (let attempt = 0; attempt <= SEARCH_RETRY_ATTEMPTS; attempt++) {
+        try {
+            const result = await searchProductsOnce(store, keyword, zipCode);
+            if (result.ok) return result.list;
+            lastReason = result;
+            // Only retry on the upstream "TimeOut Error" (101002) or 5xx-equivalent.
+            const retriable = result.reason === 'api_code_101002' || /^http_5\d\d$/.test(result.reason || '');
+            if (!retriable || attempt === SEARCH_RETRY_ATTEMPTS) break;
+            // Bust cookie jar between retries in case Cloudflare token went stale.
+            cookieJar.fetchedAt = 0;
+            const backoff = SEARCH_RETRY_BASE_MS * Math.pow(2, attempt);
+            await new Promise((r) => setTimeout(r, backoff));
+        } catch (error) {
+            lastReason = { reason: 'exception', message: error.message, status: error.response?.status };
+            if (error.response?.status) {
+                await logHttpErrorToDatabase({
+                    storeEnum: '99ranch', zipCode, storeId: String(store?.id),
+                    ingredientName: keyword, httpStatus: error.response.status, errorMessage: error.message,
+                });
+            }
+            if (attempt === SEARCH_RETRY_ATTEMPTS) break;
+            const backoff = SEARCH_RETRY_BASE_MS * Math.pow(2, attempt);
+            await new Promise((r) => setTimeout(r, backoff));
         }
-        return [];
     }
+    log.error(
+        `99 Ranch search failed for keyword="${keyword}" zip=${zipCode} store=${store?.id} after ${SEARCH_RETRY_ATTEMPTS + 1} attempts:`,
+        JSON.stringify(lastReason),
+    );
+    // Throw so the result cache does not memoize an empty result for 5 minutes.
+    const err = new Error(`99ranch_search_failed:${lastReason?.reason || 'unknown'}`);
+    err.scraperReason = lastReason;
+    throw err;
 }
 
-const DEFAULT_99_RANCH_ZIP = process.env.DEFAULT_99_RANCH_ZIP || "94709"
+const DEFAULT_99_RANCH_ZIP = process.env.DEFAULT_99_RANCH_ZIP || '94709';
 
 function format99RanchStoreLocation(storeInfo, fallbackZip) {
-    if (storeInfo?.fullAddress) {
-        return storeInfo.fullAddress;
-    }
-
+    if (storeInfo?.fullAddress) return storeInfo.fullAddress;
     const city = storeInfo?.city;
     const state = storeInfo?.state;
-    if (city && state) {
-        return `${city}, ${state}`;
-    }
-
-    if (fallbackZip) {
-        return `99 Ranch (${fallbackZip})`;
-    }
-
-    return storeInfo?.name || "99 Ranch Market";
+    if (city && state) return `${city}, ${state}`;
+    if (fallbackZip) return `99 Ranch (${fallbackZip})`;
+    return storeInfo?.name || '99 Ranch Market';
 }
 
 // 99ranch API appends quantity+unit info directly to product names, e.g.
@@ -185,70 +231,66 @@ function stripRanchQuantitySuffix(name) {
 async function search99Ranch(keyword, zipCode) {
     const cacheKey = resultCache.buildKey(keyword, zipCode);
     return resultCache.runCached(cacheKey, async () => {
-        try {
-            const userZip = (zipCode && zipCode.trim()) || DEFAULT_99_RANCH_ZIP;
-            let searchZip = userZip;
-            let store = await getNearestStore(userZip);
-            if (!store && userZip !== DEFAULT_99_RANCH_ZIP) {
-                log.warn(`No 99 Ranch store near ${userZip}, falling back to ${DEFAULT_99_RANCH_ZIP}`);
-                store = await getNearestStore(DEFAULT_99_RANCH_ZIP);
-                searchZip = DEFAULT_99_RANCH_ZIP;
-            }
-            if (!store?.id) {
-                log.warn("No nearby 99 Ranch store found for zip code:", zipCode);
-                return [];
-            }
-
-            const products = await searchProducts(store, keyword, searchZip);
-            const storeLocation = format99RanchStoreLocation(store, searchZip);
-            return products
-                .map((p) => {
-                    const productName = stripRanchQuantitySuffix((p.productName || p.productNameEN || "").trim());
-                    const price = Number.parseFloat(String(p.salePrice ?? p.price ?? ""));
-                    const productIdRaw = p.productId ?? p.id ?? p.sku ?? p.upc ?? null;
-                    const productId = productIdRaw == null ? null : String(productIdRaw);
-
-                    return {
-                        product_name: productName,
-                        title: productName || "Unknown Product",
-                        brand: p.brandName || p.brandNameEN || "",
-                        price: Number.isFinite(price) ? price : null,
-                        pricePerUnit: p.saleUom || "",
-                        unit: p.variantName || p.variantNameEN || "",
-                        rawUnit: p.variantName || p.variantNameEN || "",
-                        image_url: p.image || p.productImage?.path || "",
-                        provider: "99 Ranch",
-                        product_id: productId,
-                        id: productId,
-                        location: storeLocation,
-                        category: p.category || "Grocery",
-                    };
-                })
-                .filter((p) => p.price != null && p.price > 0 && p.product_name);
-        } catch (error) {
-            log.error("Error in 99 Ranch scraper:", error.message);
+        const userZip = (zipCode && zipCode.trim()) || DEFAULT_99_RANCH_ZIP;
+        let searchZip = userZip;
+        let store = await getNearestStore(userZip);
+        if (!store && userZip !== DEFAULT_99_RANCH_ZIP) {
+            log.warn(`No 99 Ranch store near ${userZip}, falling back to ${DEFAULT_99_RANCH_ZIP}`);
+            store = await getNearestStore(DEFAULT_99_RANCH_ZIP);
+            searchZip = DEFAULT_99_RANCH_ZIP;
+        }
+        if (!store?.id) {
+            log.warn('No nearby 99 Ranch store found for zip code:', zipCode);
             return [];
         }
+
+        let products;
+        try {
+            products = await searchProducts(store, keyword, searchZip);
+        } catch (error) {
+            log.error('Error in 99 Ranch scraper:', error.message);
+            // Re-throw so result cache does not poison with [].
+            throw error;
+        }
+        const storeLocation = format99RanchStoreLocation(store, searchZip);
+        return products
+            .map((p) => {
+                const productName = stripRanchQuantitySuffix((p.productName || p.productNameEN || '').trim());
+                const price = Number.parseFloat(String(p.salePrice ?? p.price ?? ''));
+                const productIdRaw = p.productId ?? p.id ?? p.sku ?? p.upc ?? null;
+                const productId = productIdRaw == null ? null : String(productIdRaw);
+
+                return {
+                    product_name: productName,
+                    title: productName || 'Unknown Product',
+                    brand: p.brandName || p.brandNameEN || '',
+                    price: Number.isFinite(price) ? price : null,
+                    pricePerUnit: p.saleUom || '',
+                    unit: p.variantName || p.variantNameEN || '',
+                    rawUnit: p.variantName || p.variantNameEN || '',
+                    image_url: p.image || p.productImage?.path || '',
+                    provider: '99 Ranch',
+                    product_id: productId,
+                    id: productId,
+                    location: storeLocation,
+                    category: p.category || 'Grocery',
+                };
+            })
+            .filter((p) => p.price != null && p.price > 0 && p.product_name);
     });
 }
 
 async function search99RanchBatch(keywords, zipCode, options = {}) {
-    if (!Array.isArray(keywords) || keywords.length === 0) {
-        return [];
-    }
+    if (!Array.isArray(keywords) || keywords.length === 0) return [];
 
     const requestedConcurrency = Number(options?.concurrency || DEFAULT_BATCH_CONCURRENCY);
     const concurrency = Math.max(1, Math.min(MAX_BATCH_CONCURRENCY, requestedConcurrency));
 
     const results = new Array(keywords.length);
     let cursor = 0;
-    let fatalError = null;
 
     async function worker() {
         while (cursor < keywords.length) {
-            if (fatalError) {
-                return;
-            }
             const index = cursor++;
             const keyword = keywords[index];
             try {
@@ -261,22 +303,17 @@ async function search99RanchBatch(keywords, zipCode, options = {}) {
     }
 
     await Promise.all(Array.from({ length: concurrency }, () => worker()));
-    if (fatalError) {
-        throw fatalError;
-    }
     return results;
 }
 
-// Export the function for use in other modules
 module.exports = { search99Ranch, search99RanchBatch };
 
-// Run if called directly
 if (require.main === module) {
     const keyword = process.argv[2];
     const zipCode = process.argv[3];
 
     if (!keyword || !zipCode) {
-        log.error("Usage: node 99ranch.js <keyword> <zipCode>");
+        log.error('Usage: node 99ranch.js <keyword> <zipCode>');
         process.exit(1);
     }
 


### PR DESCRIPTION
## Why

99 Ranch search has been failing in prod (returns 0 results). Code itself is fine — direct test from Sauna shows the existing scraper request shape returns 56 results for "garlic" at zip 94709, store 1781.

The likely culprit is **Cloudflare bot fingerprinting from datacenter IPs**: missing `sec-ch-*` / `sec-fetch-*` headers escalates to challenges that surface as opaque upstream `code: 101002 "TimeOut Error"` on the search endpoint. The store-locator and homepage are less aggressive about it.

## Changes

- Full Chrome header set (`sec-ch-ua`, `sec-ch-ua-platform`, `sec-fetch-*`) applied to all 3 endpoints
- Homepage warm-up captures `Set-Cookie` (incl. `__cf_bm` / `cf_clearance`), forwarded on subsequent calls. Cached 20 min in-process.
- Non-zero API codes now logged with `code` + `message` instead of silently returning `[]`
- Retry on `101002` (and 5xx) with exponential backoff; busts cookie jar between retries
- **Throws** on hard failure so `result-cache` does not poison the next 5 minutes with an empty array
- Batch worker still catches and returns `[]` so single-keyword failures do not nuke the whole batch

## Test

```
SCRAPER_RUNNER_STORE=99ranch \
  SCRAPER_RUNNER_QUERY=garlic \
  SCRAPER_RUNNER_ZIP_CODE=94709 \
  node backend/workers/scraper-worker/runner.js
```

If the warm-up cookies are not enough on prod IPs, next escalation is residential proxy (Bright Data / Smartproxy) wired through axios via `HTTPS_PROXY`.

First PR in the scraper revival series. Next up: Safeway → Whole Foods.