### PR TITLE
fix(scraper/safeway): revive Playwright impl, regex-first, LLM off by default

### DIFF
--- a/backend/workers/scraper-worker/stores/safeway.js
+++ b/backend/workers/scraper-worker/stores/safeway.js
@@ -3,6 +3,7 @@ const chromium = require('@sparticuz/chromium');
 const path = require('path');
 const { createScraperLogger } = require('../utils/logger');
 const { withScraperTimeout } = require('../utils/runtime-config');
+const { createRateLimiter } = require('../utils/rate-limiter');
 const { getOpenAIApiKey, hasConfiguredOpenAIKey, requestOpenAIJson } = require('../utils/jina/llm-fallback');
 require('dotenv').config({ path: path.join(__dirname, '../../.env.local') });
 const log = createScraperLogger('safeway');
@@ -15,6 +16,25 @@ const OPENAI_API_KEY = getOpenAIApiKey();
 // 0 means no cap: return all scraped items.
 const SAFEWAY_MAX_RESULTS = Number(process.env.SAFEWAY_MAX_RESULTS || process.env.SCRAPER_MAX_RESULTS || 0);
 
+// LLM fallback is OFF by default — regex parsing has been the reliable path.
+// Set SAFEWAY_LLM_FALLBACK=true to allow LLM extraction when regex finds zero items.
+const SAFEWAY_ENABLE_LLM_FALLBACK = process.env.SAFEWAY_LLM_FALLBACK === 'true';
+
+// Hard kill switch for the scraper. Set SAFEWAY_DISABLED=true to short-circuit and
+// return [] without launching Playwright (the previous "dummy" mode).
+const SAFEWAY_DISABLED = process.env.SAFEWAY_DISABLED === 'true';
+
+const PAGE_NAV_TIMEOUT_MS = Number(process.env.SAFEWAY_PAGE_TIMEOUT_MS || 60000);
+const PRODUCT_WAIT_TIMEOUT_MS = Number(process.env.SAFEWAY_PRODUCT_WAIT_MS || 15000);
+
+const { enforceRateLimit } = createRateLimiter({
+    requestsPerSecond: Number(process.env.SAFEWAY_REQUESTS_PER_SECOND || 1),
+    minIntervalMs: Number(process.env.SAFEWAY_MIN_REQUEST_INTERVAL_MS || 2000),
+    enableJitter: process.env.SAFEWAY_ENABLE_JITTER !== 'false',
+    log,
+    label: '[safeway]',
+});
+
 // Function to fetch RAW data (Text + Images) from Instacart via Playwright
 async function fetchRawInstacartData(keyword, zipCode) {
     let browser = null;
@@ -23,62 +43,57 @@ async function fetchRawInstacartData(keyword, zipCode) {
     try {
         log.debug(`Fetching raw data for '${keyword}' in ${zipCode} via Playwright...`);
 
-        // Launch browser using playwright-core and sparticuz-chromium
         browser = await playwright.chromium.launch({
             args: chromium.args,
             executablePath: await chromium.executablePath(),
-            headless: chromium.headless, // Use chromium's headless setting for server compatibility
+            headless: chromium.headless,
         });
-        
+
         const context = await browser.newContext({
             viewport: { width: 1920, height: 1080 },
-            userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
+            locale: 'en-US',
         });
 
         const page = await context.newPage();
 
-        // 1. Direct Navigation
         await page.goto(`https://www.instacart.com/store/safeway/search/${encodeURIComponent(keyword)}`, {
-            timeout: 60000
+            timeout: PAGE_NAV_TIMEOUT_MS,
+            waitUntil: 'domcontentloaded',
         });
 
-        // 2. Handle Zip Code / Login Wall
+        // Handle Zip Code / Login Wall
         try {
-            const zipInput = page.getByLabel("Zip code");
+            const zipInput = page.getByLabel('Zip code');
             if (await zipInput.count() > 0 && await zipInput.isVisible()) {
                 log.debug(`Entering Zip Code: ${zipCode}`);
                 await zipInput.fill(zipCode);
-                await zipInput.press("Enter");
-                await page.waitForLoadState("networkidle");
+                await zipInput.press('Enter');
+                await page.waitForLoadState('networkidle', { timeout: 20000 }).catch(() => {});
                 await page.waitForTimeout(3000);
             }
 
-            // Handle "Close" button with Strict Mode safety
-            // Filter for visible buttons only, then take the first one
-            const closeBtn = page.locator("button[aria-label='Close']").filter({ hasText: /.*/, visible: true }).first();
-            
+            // Dismiss login modal if present
+            const closeBtn = page.locator("button[aria-label='Close']").filter({ visible: true }).first();
             if (await closeBtn.count() > 0) {
-                log.debug("Dismissing login modal...");
-                await closeBtn.click();
+                log.debug('Dismissing login modal...');
+                await closeBtn.click().catch(() => {});
                 await page.waitForTimeout(1000);
             }
-
         } catch (navError) {
             log.warn(`Navigation/Zip warning: ${navError.message}`);
         }
 
-        // 3. Wait for products to load
+        // Wait for product cards
         try {
-            await page.waitForSelector('li', { timeout: 15000 });
-            // Extra wait for lazy-loaded images
-            await page.waitForTimeout(3000);
-        } catch (e) {
-            log.warn("Timeout waiting for product list items");
+            await page.waitForSelector('li', { timeout: PRODUCT_WAIT_TIMEOUT_MS });
+            await page.waitForTimeout(3000); // lazy-loaded images
+        } catch {
+            log.warn('Timeout waiting for product list items');
         }
 
-        // 4. Scrape Raw Text and Images
-        // We look for list items containing a "$" symbol
-        const items = await page.locator('li').filter({ hasText: "$" }).all();
+        // Scrape Raw Text and Images
+        const items = await page.locator('li').filter({ hasText: '$' }).all();
         log.debug(`Found ${items.length} potential item cards.`);
 
         let count = 0;
@@ -86,107 +101,90 @@ async function fetchRawInstacartData(keyword, zipCode) {
             if (SAFEWAY_MAX_RESULTS > 0 && count >= SAFEWAY_MAX_RESULTS) break;
 
             const text = (await item.innerText()).trim();
-            
-            if (text.length > 10 && text.includes("$")) {
-                let imgUrl = "";
+            if (text.length > 10 && text.includes('$')) {
+                let imgUrl = '';
                 try {
-                    const imgLocator = item.locator("img").first();
+                    const imgLocator = item.locator('img').first();
                     if (await imgLocator.count() > 0) {
-                        const srcset = await imgLocator.getAttribute("srcset");
-                        const src = await imgLocator.getAttribute("src");
-
-                        if (srcset) {
-                            // Split by space to get the first URL, remove trailing comma
-                            imgUrl = srcset.split(" ")[0].replace(/,$/, '');
-                        } else if (src) {
-                            imgUrl = src;
-                        }
+                        const srcset = await imgLocator.getAttribute('srcset');
+                        const src = await imgLocator.getAttribute('src');
+                        if (srcset) imgUrl = srcset.split(' ')[0].replace(/,$/, '');
+                        else if (src) imgUrl = src;
                     }
-                } catch (err) {
+                } catch {
                     // Ignore image extraction errors
                 }
 
-                rawData.push({
-                    text: text,
-                    img: imgUrl
-                });
+                rawData.push({ text, img: imgUrl });
                 count++;
             }
         }
-
     } catch (error) {
-        log.error("Playwright Scraping Error:", error.message);
-        return []; 
+        log.error('Playwright Scraping Error:', error.message);
+        return [];
     } finally {
-        if (browser) await browser.close();
+        if (browser) await browser.close().catch(() => {});
     }
 
     return rawData;
 }
 
-// Function to parse products from Playwright raw items using regex (runs before LLM fallback).
-// Each rawDataObject has { text: string, img: string } where text is the full inner text
-// of an Instacart/Safeway product card (multi-line, messy).
-// Typical card text:
+// Parse products from Playwright raw items using regex (primary path).
+// Each rawDataObject has { text, img } where text is the multi-line inner text
+// of an Instacart product card. Typical card text:
 //   "Signature SELECT Ice Cream\nAssorted varieties, 48 oz\n$3.99\n$0.08/oz"
 function parseRawItemsWithRegex(rawDataObjects) {
     const products = [];
 
     for (const item of rawDataObjects) {
-        const text = String(item.text || "").trim();
+        const text = String(item.text || '').trim();
         if (!text) continue;
 
-        // Extract the first dollar-sign price (unit price, not per-oz price)
-        // We want "$3.99" not "$0.08/oz" — match the largest price to avoid per-unit prices
+        // Largest dollar value = item price (avoids per-unit prices like $0.08/oz)
         const priceMatches = [...text.matchAll(/\$\s*(\d+(?:\.\d{1,2})?)/g)];
         if (priceMatches.length === 0) continue;
-
-        // Pick the largest price value (most likely the item price, not per-unit)
-        const price = Math.max(...priceMatches.map(m => parseFloat(m[1])));
+        const price = Math.max(...priceMatches.map((m) => parseFloat(m[1])));
         if (!price || price <= 0) continue;
 
-        // Extract pricePerUnit if present (e.g. "$0.83/oz")
         const ppuMatch = text.match(/\$[\d.]+\s*\/\s*([^\n$]{1,20})/);
-        const pricePerUnit = ppuMatch ? ppuMatch[0].trim() : "";
-        const unit = ppuMatch ? ppuMatch[1].trim() : "";
+        const pricePerUnit = ppuMatch ? ppuMatch[0].trim() : '';
+        const unit = ppuMatch ? ppuMatch[1].trim() : '';
 
-        // First non-empty, non-price line = product title
-        const lines = text.split(/\n/).map(l => l.trim()).filter(Boolean);
-        const titleLine = lines.find(l => !l.startsWith("$") && l.length > 3);
+        const lines = text.split(/\n/).map((l) => l.trim()).filter(Boolean);
+        const titleLine = lines.find((l) => !l.startsWith('$') && l.length > 3);
         if (!titleLine) continue;
 
         products.push({
             id: `sw-${Math.floor(Math.random() * 90000) + 10000}`,
             title: titleLine,
-            brand: "Safeway",
+            brand: 'Safeway',
             price,
             pricePerUnit,
             unit,
             rawUnit: unit,
-            image_url: item.img || "/placeholder.svg",
-            provider: "Safeway",
-            location: "Safeway Store",
-            category: "Grocery"
+            image_url: item.img || '/placeholder.svg',
+            provider: 'Safeway',
+            location: 'Safeway Store',
+            category: 'Grocery',
         });
     }
 
     return products;
 }
 
-// Function to parse products from raw data using LLM
 async function parseProductsWithLLM(rawDataObjects, keyword) {
     try {
         log.debug(`Parsing ${rawDataObjects.length} items with LLM...`);
 
         if (!hasConfiguredOpenAIKey(OPENAI_API_KEY)) {
-            log.warn("Missing OPENAI_API_KEY, cannot parse Safeway products with LLM");
+            log.warn('Missing OPENAI_API_KEY, cannot parse Safeway products with LLM');
             return [];
         }
 
         const llmInput = rawDataObjects.map((item, index) => ({
             id: index,
             text_content: item.text,
-            img_src: item.img
+            img_src: item.img,
         }));
 
         const prompt = `
@@ -222,7 +220,7 @@ Rules:
 
         const parsedProducts = await requestOpenAIJson({
             prompt,
-            systemPrompt: "You are a precise JSON extraction API.",
+            systemPrompt: 'You are a precise JSON extraction API.',
             openAiApiKey: OPENAI_API_KEY,
             maxTokens: 2500,
             temperature: 0.1,
@@ -230,108 +228,123 @@ Rules:
         });
 
         if (!Array.isArray(parsedProducts)) {
-            log.warn("No content returned from LLM");
+            log.warn('No content returned from LLM');
             return [];
         }
 
-        return parsedProducts.map(p => ({
+        return parsedProducts.map((p) => ({
             id: `sw-${Math.floor(Math.random() * 90000) + 10000}`,
-            title: p.title || "Unknown",
-            brand: p.brand || "Safeway",
+            title: p.title || 'Unknown',
+            brand: p.brand || 'Safeway',
             price: parseFloat(p.price || 0),
-            pricePerUnit: "",
-            unit: "",
-            rawUnit: "",
-            image_url: p.image_url || "/placeholder.svg",
-            provider: "Safeway",
-            location: "Safeway Store", 
-            category: "Grocery"
+            pricePerUnit: '',
+            unit: '',
+            rawUnit: '',
+            image_url: p.image_url || '/placeholder.svg',
+            provider: 'Safeway',
+            location: 'Safeway Store',
+            category: 'Grocery',
         }));
-
     } catch (error) {
-        log.error("Error parsing products with LLM:", error.message);
+        log.error('Error parsing products with LLM:', error.message);
         return [];
     }
 }
 
-// Main Safeway search function
 async function searchSafeway(keyword, zipCode) {
-    const dummySafewayScraper = async (kw, zip) => {
-        log.debug(`[safeway] Dummy scraper active. Skipping keyword="${kw}" zip="${zip || ""}"`);
+    if (SAFEWAY_DISABLED) {
+        log.debug(`[safeway] SAFEWAY_DISABLED=true, skipping keyword="${keyword}" zip="${zipCode || ''}"`);
         return [];
-    };
+    }
 
-    // Temporarily disabled real implementation:
-    /*
-    const { createRateLimiter } = require('../utils/rate-limiter');
-    const { enforceRateLimit } = createRateLimiter({
-        requestsPerSecond: Number(process.env.SAFEWAY_REQUESTS_PER_SECOND || 1),
-        minIntervalMs: Number(process.env.SAFEWAY_MIN_REQUEST_INTERVAL_MS || 2000),
-        enableJitter: process.env.SAFEWAY_ENABLE_JITTER !== 'false',
-        log,
-        label: '[safeway]',
-    });
     try {
         await enforceRateLimit();
         const rawData = await fetchRawInstacartData(keyword, zipCode);
         if (!rawData || rawData.length === 0) {
-            log.debug("Failed to fetch raw data via Playwright");
+            log.warn(`Safeway: no raw data for "${keyword}" in ${zipCode} (Instacart returned no cards)`);
             return [];
         }
 
-        // Step 1: Try regex extraction (fast, no API call)
+        // Step 1: regex extraction (fast, free, primary path)
         const regexProducts = parseRawItemsWithRegex(rawData);
         if (regexProducts.length > 0) {
             log.debug(`Regex extracted ${regexProducts.length} products from Safeway`);
             return regexProducts.sort((a, b) => a.price - b.price);
         }
 
-        // Step 2: Regex found nothing — fall back to LLM
-        log.debug("Regex found no products, falling back to LLM");
+        // Step 2: optional LLM fallback (gated by env flag)
+        if (!SAFEWAY_ENABLE_LLM_FALLBACK) {
+            log.warn(`Safeway: regex found 0 products and LLM fallback disabled (set SAFEWAY_LLM_FALLBACK=true to enable). Raw card sample: ${JSON.stringify(rawData[0]?.text?.slice(0, 200))}`);
+            return [];
+        }
+
+        log.debug('Regex found no products, falling back to LLM');
         const products = await parseProductsWithLLM(rawData, keyword);
         if (products.length === 0) {
-            log.debug("LLM failed to parse products");
+            log.warn('LLM failed to parse products');
             return [];
         }
 
         log.debug(`LLM extracted ${products.length} products from Safeway`);
         return products.sort((a, b) => a.price - b.price);
     } catch (error) {
-        log.error("Error in Safeway search:", error.message);
+        log.error('Error in Safeway search:', error.message);
         return [];
     }
-    */
+}
 
-    return dummySafewayScraper(keyword, zipCode);
+async function searchSafewayBatch(keywords, zipCode, options = {}) {
+    if (!Array.isArray(keywords) || keywords.length === 0) return [];
+
+    // Playwright is heavy — keep concurrency low.
+    const requested = Number(options?.concurrency || process.env.SAFEWAY_BATCH_CONCURRENCY || 1);
+    const concurrency = Math.max(1, Math.min(2, requested));
+
+    const results = new Array(keywords.length);
+    let cursor = 0;
+
+    async function worker() {
+        while (cursor < keywords.length) {
+            const index = cursor++;
+            const keyword = keywords[index];
+            try {
+                results[index] = await searchSafeway(keyword, zipCode);
+            } catch (error) {
+                log.error('[safeway] Batch worker error:', error.message || error);
+                results[index] = [];
+            }
+        }
+    }
+
+    await Promise.all(Array.from({ length: concurrency }, () => worker()));
+    return results;
 }
 
 // Main execution
 async function main() {
     const keyword = process.argv[2];
     const zipCode = process.argv[3];
-    
+
     if (!keyword || !zipCode) {
-        log.error("Usage: node safeway.js <keyword> <zipCode>");
-        log.error("Note: You need OPENAI_API_KEY environment variable");
+        log.error('Usage: node safeway.js <keyword> <zipCode>');
         process.exit(1);
     }
 
     try {
-        log.debug(`🔍 Safeway dummy scraper active for "${keyword}" in ${zipCode}...`);
+        log.debug(`Safeway scraper running for "${keyword}" in ${zipCode}...`);
         const results = await searchSafeway(keyword, zipCode);
         console.log(JSON.stringify(results, null, 2));
     } catch (err) {
-        log.error("Error in main:", err);
+        log.error('Error in main:', err);
         console.log(JSON.stringify([], null, 2));
     }
 }
 
-// Export
 module.exports = {
-    searchSafeway
+    searchSafeway,
+    searchSafewayBatch,
 };
 
-// Run if called directly
 if (require.main === module) {
     main();
 }


### PR DESCRIPTION
## Why

Safeway scraper was returning the dummy [] (real impl commented out). Direct Safeway / shop.safeway.com APIs are locked behind Akamai/Incapsula — not viable. Instacart's Safeway storefront is fully client-rendered (no SSR, no `__NEXT_DATA__`, GraphQL behind persisted queries) so HTTP scraping is out. Playwright is the right tool here.

## Changes

- Re-enable the Playwright + Instacart implementation that was commented out
- **Regex parsing is the only path by default** — it was already extracting products reliably; the OpenAI LLM fallback was extra cost + latency for no win. Behind `SAFEWAY_LLM_FALLBACK=true` if needed.
- Add `SAFEWAY_DISABLED=true` kill switch to restore the old dummy mode without code changes
- Add rate limiter (was missing in the previous live impl)
- Add `searchSafewayBatch` matching the pattern other scrapers use, capped at concurrency 2 since Playwright is heavy
- UA bumped to Chrome 135, locale set to en-US
- Improved error logs: when regex finds 0 products, log a sample raw card text so we can see if Instacart's DOM shifted
- Selectors made resilient: dismissed login modal best-effort, networkidle wait wrapped in catch

## Risk

- Playwright in Docker requires `@sparticuz/chromium` to be installed and a writable `/tmp`. The existing `Dockerfile.daily-scraper` and `Dockerfile.frontend-scraper` already build with this stack, but worth a smoke test.
- Instacart UI selectors (`li` with `$` text, `button[aria-label='Close']`) are stable as of the original implementation but should be watched.

## Test

```
SCRAPER_RUNNER_STORE=safeway \
  SCRAPER_RUNNER_QUERY=garlic \
  SCRAPER_RUNNER_ZIP_CODE=94709 \
  node backend/workers/scraper-worker/runner.js
```

If 0 results, check logs for "raw card sample" — that tells you if the DOM shifted vs. zip-wall vs. Instacart bot block. Next step there is a residential proxy or a more Stealth-flavored Playwright config.