### PR TITLE
fix(scraper/wholefoods): replace dummy with Playwright DOM scraper

### DIFF
--- a/backend/workers/scraper-worker/stores/wholefoods.js
+++ b/backend/workers/scraper-worker/stores/wholefoods.js
@@ -1,105 +1,254 @@
-const axios = require('axios');
+const playwright = require('playwright-core');
+const chromium = require('@sparticuz/chromium');
+const path = require('path');
 const { createScraperLogger } = require('../utils/logger');
 const { withScraperTimeout } = require('../utils/runtime-config');
-const log = createScraperLogger('wholefoods');
+const { createRateLimiter } = require('../utils/rate-limiter');
+require('dotenv').config({ path: path.join(__dirname, '../../.env.local') });
 
-// Utility function to handle timeouts
+const log = createScraperLogger('wholefoods');
 const withTimeout = (promise, ms) => withScraperTimeout(promise, ms);
 
-async function searchWholeFoods(keyword, zipCode) {
-    const dummyWholeFoodsScraper = async (kw, zip) => {
-        log.debug(`[wholefoods] Dummy scraper active. Skipping keyword="${kw}" zip="${zip || ""}"`);
-        return [];
-    };
+// Hard kill switch.
+const WFM_DISABLED = process.env.WHOLEFOODS_DISABLED === 'true';
 
-    // Temporarily disabled real implementation:
-    // return await searchWholeFoodsReal(keyword, zipCode);
-    return dummyWholeFoodsScraper(keyword, zipCode);
+// 0 = no cap.
+const WFM_MAX_RESULTS = Number(process.env.WHOLEFOODS_MAX_RESULTS || process.env.SCRAPER_MAX_RESULTS || 0);
+
+const PAGE_NAV_TIMEOUT_MS = Number(process.env.WHOLEFOODS_PAGE_TIMEOUT_MS || 60000);
+const PRODUCT_WAIT_TIMEOUT_MS = Number(process.env.WHOLEFOODS_PRODUCT_WAIT_MS || 20000);
+
+const { enforceRateLimit } = createRateLimiter({
+    requestsPerSecond: Number(process.env.WHOLEFOODS_REQUESTS_PER_SECOND || 1),
+    minIntervalMs: Number(process.env.WHOLEFOODS_MIN_REQUEST_INTERVAL_MS || 2000),
+    enableJitter: process.env.WHOLEFOODS_ENABLE_JITTER !== 'false',
+    log,
+    label: '[wholefoods]',
+});
+
+// Whole Foods is owned by Amazon. Their /search page on wholefoodsmarket.com
+// is a Next.js app that fetches results client-side after render. There's no
+// stable, unauthenticated JSON endpoint we can hit, and Amazon's bot
+// protection on the API is aggressive. Playwright + DOM scrape is the path.
+async function fetchRawWFMData(keyword, zipCode) {
+    let browser = null;
+    const rawData = [];
+
+    try {
+        log.debug(`Fetching Whole Foods data for '${keyword}' zip=${zipCode || 'none'}...`);
+
+        browser = await playwright.chromium.launch({
+            args: chromium.args,
+            executablePath: await chromium.executablePath(),
+            headless: chromium.headless,
+        });
+
+        const context = await browser.newContext({
+            viewport: { width: 1920, height: 1080 },
+            userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
+            locale: 'en-US',
+        });
+
+        const page = await context.newPage();
+
+        await page.goto(`https://www.wholefoodsmarket.com/search?text=${encodeURIComponent(keyword)}`, {
+            timeout: PAGE_NAV_TIMEOUT_MS,
+            waitUntil: 'domcontentloaded',
+        });
+
+        // Best-effort cookie / location prompt dismissal.
+        try {
+            for (const sel of [
+                "button:has-text('Accept')",
+                "button[aria-label='Close']",
+                "button:has-text('No thanks')",
+            ]) {
+                const btn = page.locator(sel).filter({ visible: true }).first();
+                if (await btn.count() > 0) {
+                    await btn.click({ timeout: 2000 }).catch(() => {});
+                }
+            }
+        } catch {
+            // noop
+        }
+
+        // Try product card selectors in order of stability. WFM ships several
+        // testid variants over time; falling back is cheaper than guessing.
+        const candidates = [
+            "[data-testid='product-tile']",
+            "[data-testid='product-card']",
+            "article[data-testid*='product']",
+            "li[data-testid*='product']",
+        ];
+
+        let foundSelector = null;
+        for (const sel of candidates) {
+            try {
+                await page.waitForSelector(sel, { timeout: PRODUCT_WAIT_TIMEOUT_MS / candidates.length });
+                foundSelector = sel;
+                break;
+            } catch {
+                continue;
+            }
+        }
+
+        if (!foundSelector) {
+            // Fallback: any element containing a price.
+            log.warn('WFM: no known product-tile selector matched; falling back to generic $ scan.');
+            foundSelector = ":is(article, li, div):has(:text('$'))";
+        }
+
+        await page.waitForTimeout(2000); // lazy images
+
+        const cards = await page.locator(foundSelector).all();
+        log.debug(`WFM: found ${cards.length} cards via selector ${foundSelector}`);
+
+        let count = 0;
+        for (const card of cards) {
+            if (WFM_MAX_RESULTS > 0 && count >= WFM_MAX_RESULTS) break;
+            try {
+                const text = (await card.innerText()).trim();
+                if (!text || !text.includes('$')) continue;
+                let imgUrl = '';
+                try {
+                    const img = card.locator('img').first();
+                    if (await img.count() > 0) {
+                        imgUrl = (await img.getAttribute('src')) || '';
+                    }
+                } catch {}
+                let href = '';
+                try {
+                    const link = card.locator('a').first();
+                    if (await link.count() > 0) href = (await link.getAttribute('href')) || '';
+                } catch {}
+                rawData.push({ text, img: imgUrl, href });
+                count++;
+            } catch (cardErr) {
+                log.debug('WFM: card scrape error:', cardErr.message);
+            }
+        }
+    } catch (error) {
+        log.error('Whole Foods Playwright error:', error.message);
+        return [];
+    } finally {
+        if (browser) await browser.close().catch(() => {});
+    }
+
+    return rawData;
 }
 
-function extractProductsFromHTML(html) {
+function parseRawItemsWithRegex(rawDataObjects) {
+    const products = [];
+    for (const item of rawDataObjects) {
+        const text = String(item.text || '').trim();
+        if (!text) continue;
+
+        // WFM cards typically: "Brand\nProduct name, size\n$X.XX\n$X.XX/oz" or similar.
+        const priceMatches = [...text.matchAll(/\$\s*(\d+(?:\.\d{1,2})?)/g)];
+        if (priceMatches.length === 0) continue;
+        const price = Math.max(...priceMatches.map((m) => parseFloat(m[1])));
+        if (!price || price <= 0) continue;
+
+        const ppuMatch = text.match(/\$[\d.]+\s*\/\s*([^\n$]{1,20})/);
+        const pricePerUnit = ppuMatch ? ppuMatch[0].trim() : '';
+        const unit = ppuMatch ? ppuMatch[1].trim() : '';
+
+        const lines = text.split(/\n/).map((l) => l.trim()).filter(Boolean);
+        const titleLine = lines.find((l) => !l.startsWith('$') && l.length > 3);
+        if (!titleLine) continue;
+
+        // First line that's not the title and not a price ~ brand.
+        const brandLine = lines.find((l) => l !== titleLine && !l.startsWith('$') && l.length > 1 && l.length < 40);
+
+        const productId = item.href ? item.href.split('/').filter(Boolean).pop() : null;
+
+        products.push({
+            id: productId || `wfm-${Math.floor(Math.random() * 90000) + 10000}`,
+            product_id: productId,
+            title: titleLine,
+            product_name: titleLine,
+            brand: brandLine && brandLine !== titleLine ? brandLine : 'Whole Foods',
+            price,
+            pricePerUnit,
+            unit,
+            rawUnit: unit,
+            image_url: item.img || '/placeholder.svg',
+            provider: 'Whole Foods',
+            location: 'Whole Foods Market',
+            category: 'Grocery',
+        });
+    }
+    return products;
+}
+
+async function searchWholeFoods(keyword, zipCode) {
+    if (WFM_DISABLED) {
+        log.debug(`[wholefoods] WHOLEFOODS_DISABLED=true, skipping keyword="${keyword}"`);
+        return [];
+    }
+
     try {
-        // Look for product data in script tags
-        const scriptMatches = html.match(/<script[^>]*>.*?({.*?"products".*?}).*?<\/script>/s);
-        if (scriptMatches) {
-            try {
-                const data = JSON.parse(scriptMatches[1]);
-                const products = data.products || [];
-                
-                return products
-                    .filter(item => item.price && item.price > 0)
-                    .map(item => ({
-                        id: item.id || `wholefoods-${Math.random()}`,
-                        title: item.name || "Unknown Product",
-                        brand: item.brand || "",
-                        price: parseFloat(item.price) || 0,
-                        pricePerUnit: item.price_per_unit || "",
-                        unit: item.unit || "",
-                        rawUnit: item.unit || "",
-                        image_url: item.image_url || "",
-                        provider: "Whole Foods",
-                        location: "Whole Foods Market",
-                        category: item.category || "Grocery"
-                    }))
-                    .filter(p => p.price > 0)
-                    .sort((a, b) => a.price - b.price);
-            } catch (e) {
-                log.error("Failed to parse Whole Foods JSON:", e.message);
-            }
+        await enforceRateLimit();
+        const rawData = await fetchRawWFMData(keyword, zipCode);
+        if (!rawData.length) {
+            log.warn(`Whole Foods: 0 raw cards for "${keyword}"`);
+            return [];
         }
 
-        // Alternative: Look for product data in other script patterns
-        const productMatches = html.match(/window\.__INITIAL_STATE__\s*=\s*({.*?});/s);
-        if (productMatches) {
-            try {
-                const data = JSON.parse(productMatches[1]);
-                const products = data.search?.results || data.products || [];
-                
-                return products
-                    .filter(item => item.price && item.price > 0)
-                    .map(item => ({
-                        id: item.id || `wholefoods-${Math.random()}`,
-                        title: item.name || item.title || "Unknown Product",
-                        brand: item.brand || "",
-                        price: parseFloat(item.price) || 0,
-                        pricePerUnit: item.price_per_unit || "",
-                        unit: item.unit || "",
-                        rawUnit: item.unit || "",
-                        image_url: item.image_url || item.image || "",
-                        provider: "Whole Foods",
-                        location: "Whole Foods Market",
-                        category: item.category || "Grocery"
-                    }))
-                    .filter(p => p.price > 0)
-                    .sort((a, b) => a.price - b.price);
-            } catch (e) {
-                log.error("Failed to parse Whole Foods initial state:", e.message);
-            }
+        const products = parseRawItemsWithRegex(rawData);
+        if (products.length === 0) {
+            log.warn(`Whole Foods: regex parsed 0 products from ${rawData.length} cards. Sample text: ${JSON.stringify(rawData[0]?.text?.slice(0, 200))}`);
+            return [];
         }
-        
-        return [];
+
+        log.debug(`Whole Foods: extracted ${products.length} products`);
+        return products.sort((a, b) => a.price - b.price);
     } catch (error) {
-        log.error("Error extracting Whole Foods products from HTML:", error.message);
+        log.error('Error in Whole Foods search:', error.message);
         return [];
     }
 }
 
-// Export for use as a module
-module.exports = { searchWholeFoods };
+async function searchWholeFoodsBatch(keywords, zipCode, options = {}) {
+    if (!Array.isArray(keywords) || keywords.length === 0) return [];
 
-// Run if called directly
+    const requested = Number(options?.concurrency || process.env.WHOLEFOODS_BATCH_CONCURRENCY || 1);
+    const concurrency = Math.max(1, Math.min(2, requested));
+
+    const results = new Array(keywords.length);
+    let cursor = 0;
+
+    async function worker() {
+        while (cursor < keywords.length) {
+            const index = cursor++;
+            const keyword = keywords[index];
+            try {
+                results[index] = await searchWholeFoods(keyword, zipCode);
+            } catch (error) {
+                log.error('[wholefoods] Batch worker error:', error.message || error);
+                results[index] = [];
+            }
+        }
+    }
+
+    await Promise.all(Array.from({ length: concurrency }, () => worker()));
+    return results;
+}
+
+module.exports = { searchWholeFoods, searchWholeFoodsBatch };
+
 if (require.main === module) {
     const keyword = process.argv[2];
     const zipCode = process.argv[3];
 
-    if (!keyword || !zipCode) {
-        log.error("Usage: node wholefoods.js <keyword> <zipCode>");
+    if (!keyword) {
+        log.error('Usage: node wholefoods.js <keyword> [zipCode]');
         process.exit(1);
     }
 
-    searchWholeFoods(keyword, zipCode).then(results => {
-        console.log(JSON.stringify(results));
-    }).catch(err => {
+    searchWholeFoods(keyword, zipCode).then((results) => {
+        console.log(JSON.stringify(results, null, 2));
+    }).catch((err) => {
         log.error(err);
         process.exit(1);
     });


### PR DESCRIPTION
## Why

Whole Foods scraper was a dummy returning []. Investigated viable data sources:

- **Instacart Whole Foods storefront** — doesn't exist (Amazon pulled WFM off Instacart years ago, all slug variants 404)
- **wholefoodsmarket.com search HTML** — Next.js shell, no products in pre-render, no `__NEXT_DATA__` payload, no embedded `__INITIAL_STATE__`
- **/api/products/*, /api/wfm-search, /api/bff/search** — all 404
- **Direct Algolia / GraphQL endpoints** — not exposed unauthenticated, Amazon-grade bot protection

Left option: Playwright + DOM scrape, same playbook as Safeway.

## Changes

- Replace dummy implementation with full Playwright-driven WFM search scraper on `wholefoodsmarket.com/search?text=<kw>`
- Try multiple stable product-tile selectors (`[data-testid='product-tile']`, `product-card`, `article[data-testid*='product']`, `li[data-testid*='product']`) before falling back to a generic `$` scan
- Best-effort dismissal of cookie / location prompts
- Regex-based parsing into the canonical product shape (id, title, brand, price, pricePerUnit, unit, image_url, provider, location, category)
- Capture product href as stable `product_id` when available
- `searchWholeFoodsBatch` matching the worker pattern, capped at concurrency 2
- `WHOLEFOODS_DISABLED=true` kill switch to revert to dummy without code changes
- Diagnostic logs include sample card text on parse failure so we can spot DOM drift

## Risk

- WFM does not surface store-level pricing without an authenticated session and a chosen store. **Prices returned are list/national, not store-specific** — unlike Safeway/Kroger/etc. We should make this explicit in the UI or via the `location` field. Open question: do we still want WFM if we can't get user-zip pricing?
- Selectors are inferred from the page structure but not validated against rendered DOM (couldn't run Playwright in scratch env). The fallback chain + diagnostic logging compensates: if `product-tile` doesn't match, the warn log shows the raw card text and we can tighten in a follow-up.
- If WFM aggressively blocks Playwright on prod IPs, next escalation is residential proxy (same lane as 99 Ranch).

## Test

```
SCRAPER_RUNNER_STORE=wholefoods \
  SCRAPER_RUNNER_QUERY=garlic \
  SCRAPER_RUNNER_ZIP_CODE=94709 \
  node backend/workers/scraper-worker/runner.js
```