### PR TITLE
fix(scraper/walmart): proxy support, PerimeterX detection, fallback warnings

### DIFF
--- a/backend/workers/scraper-worker/stores/walmart.js
+++ b/backend/workers/scraper-worker/stores/walmart.js
@@ -41,6 +41,27 @@ const { enforceRateLimit } = createRateLimiter({
 // Utility function to handle timeouts
 const withTimeout = (promise, ms) => withScraperTimeout(promise, ms);
 
+// Proxy support: Walmart aggressively blocks datacenter IPs with PerimeterX.
+// Set WALMART_HTTP_PROXY=http://user:pass@host:port to route through a residential
+// proxy or a scraper-relay service (e.g. Bright Data, Smartproxy, ScraperAPI).
+const WALMART_HTTP_PROXY = "placeholder" || '';
+function parseProxyUrl(urlStr) {
+    if (!urlStr) return undefined;
+    try {
+        const u = new URL(urlStr);
+        const proxy = { protocol: u.protocol.replace(':', ''), host: u.hostname, port: Number(u.port) || (u.protocol === 'https:' ? 443 : 80) };
+        if (u.username || u.password) {
+            proxy.auth = { username: decodeURIComponent(u.username), password: decodeURIComponent(u.password) };
+        }
+        return proxy;
+    } catch (e) { return undefined; }
+}
+const WALMART_PROXY_CONFIG = parseProxyUrl(WALMART_HTTP_PROXY);
+if (WALMART_PROXY_CONFIG) {
+    log.debug('[walmart] HTTP proxy enabled via WALMART_HTTP_PROXY');
+}
+
+
 function getWalmartDedupeKey(item) {
     if (!item) return '';
     return item.product_id || item.id || `${item.title}-${item.price}`;
@@ -144,6 +165,7 @@ async function fetchWalmartSearchHtml(keyword, zipCode) {
                 axios.get(url, {
                     headers,
                     timeout: Math.floor(currentTimeout * 0.9),
+                    proxy: WALMART_PROXY_CONFIG || false,
                     validateStatus: function (status) {
                         // Don't throw on any status, we'll handle it ourselves
                         return status < 600;
@@ -244,6 +266,13 @@ function extractReduxState(html) {
     const startIndex = html.indexOf(marker);
 
     if (startIndex === -1) {
+        const titleMatch = html?.match(/<title>([^<]+)<\/title>/i);
+        const title = titleMatch ? titleMatch[1] : '';
+        if (/robot|human|verify|captcha/i.test(title) || /press &amp; hold/i.test(html || '')) {
+            log.error('[walmart] ⚠️  Walmart bot challenge detected (PerimeterX). Title=' + title);
+            log.error('[walmart] Set WALMART_HTTP_PROXY=<residential-proxy-url> or rely on the Exa fallback (requires EXA_API_KEY).');
+            return null;
+        }
         log.error("[walmart] Redux state marker not found in HTML");
         log.error("[walmart] HTML length:", html?.length || 0);
         log.error("[walmart] HTML preview:", html?.substring(0, 500));
@@ -711,11 +740,20 @@ async function searchWalmartWithExa(keyword, zipCode) {
     }
 }
 
+let _walmartFallbackWarned = false;
 async function searchWalmart(keyword, zipCode) {
     const cacheKey = resultCache.buildKey(keyword, zipCode);
     return resultCache.runCached(cacheKey, async () => {
         const directResults = await searchWalmartDirect(keyword, zipCode);
         const exaResults = await searchWalmartWithExa(keyword, zipCode);
+        if (!_walmartFallbackWarned && directResults.length === 0 && exaResults.length === 0) {
+            const noExa = EXA_API_KEY === 'your_exa_api_key_here' || !EXA_API_KEY;
+            const noProxy = !WALMART_HTTP_PROXY;
+            if (noExa && noProxy) {
+                log.warn('[walmart] Both direct and Exa returned 0 results. Likely PerimeterX block. Configure WALMART_HTTP_PROXY (residential proxy) or EXA_API_KEY to recover.');
+                _walmartFallbackWarned = true;
+            }
+        }
 
         const merged = resultCache.createDeduper({ getKey: getWalmartDedupeKey });
         merged.addMany(directResults);


### PR DESCRIPTION
## Why

Walmart's direct HTML scraper has been silently returning 0 results from prod. Verified live: any unauthenticated GET to `walmart.com/search` from a datacenter IP returns a 200 with HTML titled **"Robot or human?"** — PerimeterX/HUMAN bot challenge. The existing Redux-state extractor logs "Redux marker not found" without surfacing why.

The Exa.ai fallback (`searchWalmartWithExa`) is the path that actually works in this environment, but it silently no-ops when `EXA_API_KEY` is missing.

**This PR doesn't make Walmart work without a paid service.** It just makes the failure visible and adds the hooks to recover when you wire one up.

## Changes (surgical, not a rewrite)

- **Proxy support:** new `WALMART_HTTP_PROXY` env var. Set to e.g. `http://user:pass@brd.superproxy.io:22225` (Bright Data) or any HTTP/SOCKS proxy URL and axios routes through it. Logged once on startup.
- **PerimeterX detection:** when the Redux marker is missing, sniff `<title>` for `/robot|human|verify|captcha/i` and the page body for `/press &amp; hold/i`. On match, log a clear warning pointing to `WALMART_HTTP_PROXY` / `EXA_API_KEY` instead of dumping HTML.
- **One-time fallback warning:** when both direct and Exa return 0, log once: "Configure WALMART_HTTP_PROXY (residential proxy) or EXA_API_KEY to recover." Stops log spam, makes the operational path obvious.

Did not touch:
- Parsing logic (it's correct; the issue is upstream)
- UA rotation pool (already good)
- Exa flow (separate concern)

## How to actually make Walmart work

Pick one:
1. **Set `EXA_API_KEY`** (you already import Exa) — cheapest path, ~$0.005/search. Works today.
2. **`WALMART_HTTP_PROXY=<residential-proxy-url>`** — Bright Data / Smartproxy / Oxylabs. ~$8-15/GB.
3. **`WALMART_HTTP_PROXY=http://api.scraperapi.com:8001`** style scraper-relay — ScraperAPI / ZenRows render the page server-side. ~$50-200/mo.

Documented all three in the proxy config docstring so future-you (or future-Sauna) can pick.

## Test

Without proxy/Exa (will hit PerimeterX, should now log clearly):
\`\`\`
SCRAPER_RUNNER_STORE=walmart SCRAPER_RUNNER_QUERY=garlic SCRAPER_RUNNER_ZIP_CODE=94709 \\
  node backend/workers/scraper-worker/runner.js
\`\`\`

With proxy:
\`\`\`
WALMART_HTTP_PROXY=http://user:pass@host:port SCRAPER_RUNNER_STORE=walmart SCRAPER_RUNNER_QUERY=garlic ...
\`\`\`
