### PR TITLE
feat(scrapers): add 10 chains via Instacart helper (Costco, Sams, Publix, H-E-B, Wegmans, ShopRite, Stop & Shop, Food Lion, Winn-Dixie, BJs)

### DIFF
--- a/backend/workers/scraper-worker/stores/bjs.js
+++ b/backend/workers/scraper-worker/stores/bjs.js
@@ -1,0 +1,30 @@
+const { createInstacartStoreScraper } = require('./_instacart-storefront');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../../.env.local') });
+
+const { search, batch, log } = createInstacartStoreScraper({
+    slug: 'bjs',
+    providerName: "BJ's Wholesale Club",
+    providerLocation: "BJ's Wholesale Club",
+    envPrefix: 'BJS',
+});
+
+const searchBjs = search;
+const searchBjsBatch = batch;
+
+module.exports = { searchBjs, searchBjsBatch };
+
+if (require.main === module) {
+    const keyword = process.argv[2];
+    const zipCode = process.argv[3];
+    if (!keyword) {
+        log.error('Usage: node bjs.js <keyword> [zipCode]');
+        process.exit(1);
+    }
+    searchBjs(keyword, zipCode).then((results) => {
+        console.log(JSON.stringify(results, null, 2));
+    }).catch((err) => {
+        log.error(err);
+        process.exit(1);
+    });
+}

--- a/backend/workers/scraper-worker/stores/costco.js
+++ b/backend/workers/scraper-worker/stores/costco.js
@@ -1,0 +1,30 @@
+const { createInstacartStoreScraper } = require('./_instacart-storefront');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../../.env.local') });
+
+const { search, batch, log } = createInstacartStoreScraper({
+    slug: 'costco',
+    providerName: "Costco",
+    providerLocation: "Costco Wholesale",
+    envPrefix: 'COSTCO',
+});
+
+const searchCostco = search;
+const searchCostcoBatch = batch;
+
+module.exports = { searchCostco, searchCostcoBatch };
+
+if (require.main === module) {
+    const keyword = process.argv[2];
+    const zipCode = process.argv[3];
+    if (!keyword) {
+        log.error('Usage: node costco.js <keyword> [zipCode]');
+        process.exit(1);
+    }
+    searchCostco(keyword, zipCode).then((results) => {
+        console.log(JSON.stringify(results, null, 2));
+    }).catch((err) => {
+        log.error(err);
+        process.exit(1);
+    });
+}

--- a/backend/workers/scraper-worker/stores/foodlion.js
+++ b/backend/workers/scraper-worker/stores/foodlion.js
@@ -1,0 +1,30 @@
+const { createInstacartStoreScraper } = require('./_instacart-storefront');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../../.env.local') });
+
+const { search, batch, log } = createInstacartStoreScraper({
+    slug: 'food-lion',
+    providerName: "Food Lion",
+    providerLocation: "Food Lion",
+    envPrefix: 'FOODLION',
+});
+
+const searchFoodLion = search;
+const searchFoodLionBatch = batch;
+
+module.exports = { searchFoodLion, searchFoodLionBatch };
+
+if (require.main === module) {
+    const keyword = process.argv[2];
+    const zipCode = process.argv[3];
+    if (!keyword) {
+        log.error('Usage: node foodlion.js <keyword> [zipCode]');
+        process.exit(1);
+    }
+    searchFoodLion(keyword, zipCode).then((results) => {
+        console.log(JSON.stringify(results, null, 2));
+    }).catch((err) => {
+        log.error(err);
+        process.exit(1);
+    });
+}

--- a/backend/workers/scraper-worker/stores/heb.js
+++ b/backend/workers/scraper-worker/stores/heb.js
@@ -1,0 +1,30 @@
+const { createInstacartStoreScraper } = require('./_instacart-storefront');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../../.env.local') });
+
+const { search, batch, log } = createInstacartStoreScraper({
+    slug: 'h-e-b',
+    providerName: "H-E-B",
+    providerLocation: "H-E-B Grocery",
+    envPrefix: 'HEB',
+});
+
+const searchHeb = search;
+const searchHebBatch = batch;
+
+module.exports = { searchHeb, searchHebBatch };
+
+if (require.main === module) {
+    const keyword = process.argv[2];
+    const zipCode = process.argv[3];
+    if (!keyword) {
+        log.error('Usage: node heb.js <keyword> [zipCode]');
+        process.exit(1);
+    }
+    searchHeb(keyword, zipCode).then((results) => {
+        console.log(JSON.stringify(results, null, 2));
+    }).catch((err) => {
+        log.error(err);
+        process.exit(1);
+    });
+}

--- a/backend/workers/scraper-worker/stores/publix.js
+++ b/backend/workers/scraper-worker/stores/publix.js
@@ -1,0 +1,30 @@
+const { createInstacartStoreScraper } = require('./_instacart-storefront');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../../.env.local') });
+
+const { search, batch, log } = createInstacartStoreScraper({
+    slug: 'publix',
+    providerName: "Publix",
+    providerLocation: "Publix Super Markets",
+    envPrefix: 'PUBLIX',
+});
+
+const searchPublix = search;
+const searchPublixBatch = batch;
+
+module.exports = { searchPublix, searchPublixBatch };
+
+if (require.main === module) {
+    const keyword = process.argv[2];
+    const zipCode = process.argv[3];
+    if (!keyword) {
+        log.error('Usage: node publix.js <keyword> [zipCode]');
+        process.exit(1);
+    }
+    searchPublix(keyword, zipCode).then((results) => {
+        console.log(JSON.stringify(results, null, 2));
+    }).catch((err) => {
+        log.error(err);
+        process.exit(1);
+    });
+}

--- a/backend/workers/scraper-worker/stores/samsclub.js
+++ b/backend/workers/scraper-worker/stores/samsclub.js
@@ -1,0 +1,30 @@
+const { createInstacartStoreScraper } = require('./_instacart-storefront');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../../.env.local') });
+
+const { search, batch, log } = createInstacartStoreScraper({
+    slug: 'sams-club',
+    providerName: "Sam's Club",
+    providerLocation: "Sam's Club",
+    envPrefix: 'SAMSCLUB',
+});
+
+const searchSamsClub = search;
+const searchSamsClubBatch = batch;
+
+module.exports = { searchSamsClub, searchSamsClubBatch };
+
+if (require.main === module) {
+    const keyword = process.argv[2];
+    const zipCode = process.argv[3];
+    if (!keyword) {
+        log.error('Usage: node samsclub.js <keyword> [zipCode]');
+        process.exit(1);
+    }
+    searchSamsClub(keyword, zipCode).then((results) => {
+        console.log(JSON.stringify(results, null, 2));
+    }).catch((err) => {
+        log.error(err);
+        process.exit(1);
+    });
+}

--- a/backend/workers/scraper-worker/stores/shoprite.js
+++ b/backend/workers/scraper-worker/stores/shoprite.js
@@ -1,0 +1,30 @@
+const { createInstacartStoreScraper } = require('./_instacart-storefront');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../../.env.local') });
+
+const { search, batch, log } = createInstacartStoreScraper({
+    slug: 'shoprite',
+    providerName: "ShopRite",
+    providerLocation: "ShopRite Supermarkets",
+    envPrefix: 'SHOPRITE',
+});
+
+const searchShopRite = search;
+const searchShopRiteBatch = batch;
+
+module.exports = { searchShopRite, searchShopRiteBatch };
+
+if (require.main === module) {
+    const keyword = process.argv[2];
+    const zipCode = process.argv[3];
+    if (!keyword) {
+        log.error('Usage: node shoprite.js <keyword> [zipCode]');
+        process.exit(1);
+    }
+    searchShopRite(keyword, zipCode).then((results) => {
+        console.log(JSON.stringify(results, null, 2));
+    }).catch((err) => {
+        log.error(err);
+        process.exit(1);
+    });
+}

--- a/backend/workers/scraper-worker/stores/stopandshop.js
+++ b/backend/workers/scraper-worker/stores/stopandshop.js
@@ -1,0 +1,30 @@
+const { createInstacartStoreScraper } = require('./_instacart-storefront');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../../.env.local') });
+
+const { search, batch, log } = createInstacartStoreScraper({
+    slug: 'stop-shop',
+    providerName: "Stop & Shop",
+    providerLocation: "Stop & Shop",
+    envPrefix: 'STOPANDSHOP',
+});
+
+const searchStopAndShop = search;
+const searchStopAndShopBatch = batch;
+
+module.exports = { searchStopAndShop, searchStopAndShopBatch };
+
+if (require.main === module) {
+    const keyword = process.argv[2];
+    const zipCode = process.argv[3];
+    if (!keyword) {
+        log.error('Usage: node stopandshop.js <keyword> [zipCode]');
+        process.exit(1);
+    }
+    searchStopAndShop(keyword, zipCode).then((results) => {
+        console.log(JSON.stringify(results, null, 2));
+    }).catch((err) => {
+        log.error(err);
+        process.exit(1);
+    });
+}

--- a/backend/workers/scraper-worker/stores/wegmans.js
+++ b/backend/workers/scraper-worker/stores/wegmans.js
@@ -1,0 +1,30 @@
+const { createInstacartStoreScraper } = require('./_instacart-storefront');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../../.env.local') });
+
+const { search, batch, log } = createInstacartStoreScraper({
+    slug: 'wegmans',
+    providerName: "Wegmans",
+    providerLocation: "Wegmans Food Markets",
+    envPrefix: 'WEGMANS',
+});
+
+const searchWegmans = search;
+const searchWegmansBatch = batch;
+
+module.exports = { searchWegmans, searchWegmansBatch };
+
+if (require.main === module) {
+    const keyword = process.argv[2];
+    const zipCode = process.argv[3];
+    if (!keyword) {
+        log.error('Usage: node wegmans.js <keyword> [zipCode]');
+        process.exit(1);
+    }
+    searchWegmans(keyword, zipCode).then((results) => {
+        console.log(JSON.stringify(results, null, 2));
+    }).catch((err) => {
+        log.error(err);
+        process.exit(1);
+    });
+}

--- a/backend/workers/scraper-worker/stores/winndixie.js
+++ b/backend/workers/scraper-worker/stores/winndixie.js
@@ -1,0 +1,30 @@
+const { createInstacartStoreScraper } = require('./_instacart-storefront');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../../.env.local') });
+
+const { search, batch, log } = createInstacartStoreScraper({
+    slug: 'winn-dixie',
+    providerName: "Winn-Dixie",
+    providerLocation: "Winn-Dixie",
+    envPrefix: 'WINNDIXIE',
+});
+
+const searchWinnDixie = search;
+const searchWinnDixieBatch = batch;
+
+module.exports = { searchWinnDixie, searchWinnDixieBatch };
+
+if (require.main === module) {
+    const keyword = process.argv[2];
+    const zipCode = process.argv[3];
+    if (!keyword) {
+        log.error('Usage: node winndixie.js <keyword> [zipCode]');
+        process.exit(1);
+    }
+    searchWinnDixie(keyword, zipCode).then((results) => {
+        console.log(JSON.stringify(results, null, 2));
+    }).catch((err) => {
+        log.error(err);
+        process.exit(1);
+    });
+}


### PR DESCRIPTION
## Why

Stacked on top of #76 (Bay Area chains + shared Instacart helper). All ten chains in this PR are on Instacart's white-label platform, verified slugs live:

**National big-3**
- `/store/costco/search/garlic` → 200 (Costco — Instacart shows public pricing without membership)
- `/store/sams-club/search/garlic` → 200 (Sam's Club — direct samsclub.com is PerimeterX-walled, Instacart isn't)
- `/store/publix/search/garlic` → 200 (Publix)

**Regional core**
- `/store/h-e-b/search/garlic` → 200 (H-E-B)
- `/store/wegmans/search/garlic` → 200 (Wegmans)
- `/store/shoprite/search/garlic` → 200 (ShopRite)
- `/store/stop-shop/search/garlic` → 200 (Stop & Shop)

**Bonus regional**
- `/store/food-lion/search/garlic` → 200 (Food Lion — Southeast)
- `/store/winn-dixie/search/garlic` → 200 (Winn-Dixie — Southeast)
- `/store/bjs/search/garlic` → 200 (BJ's Wholesale)

**Two chains skipped:**
- Giant Food: not on Instacart under any tested slug (giant-food, giant-food-store)
- Harris Teeter: 404 on Instacart (Kroger-owned, may need Kroger-style direct API instead)

These can be follow-ups; both are smaller-footprint and not blocking.

## Changes

10 new files, each ~25 lines, all consuming `_instacart-storefront.js` from #76. Per-store env vars derive from envPrefix (e.g. `COSTCO_DISABLED`, `HEB_REQUESTS_PER_SECOND`, `SAMSCLUB_INSTACART_SLUG`).

## Test

\`\`\`
# any chain:
SCRAPER_RUNNER_STORE=heb SCRAPER_RUNNER_QUERY=garlic SCRAPER_RUNNER_ZIP_CODE=78701 node backend/workers/scraper-worker/runner.js
SCRAPER_RUNNER_STORE=publix SCRAPER_RUNNER_QUERY=garlic SCRAPER_RUNNER_ZIP_CODE=33101 node backend/workers/scraper-worker/runner.js
SCRAPER_RUNNER_STORE=costco SCRAPER_RUNNER_QUERY=garlic SCRAPER_RUNNER_ZIP_CODE=94709 node backend/workers/scraper-worker/runner.js
\`\`\`

## Risk

- Costco / Sam's / BJ's pricing on Instacart includes a delivery markup vs. in-store. If you're price-comparing, surface this in the UI or normalize.
- All 10 + 4 from #76 + 4 from earlier wave = **18 stores funneling through Instacart from one egress IP**. Aggressive batching will trigger Instacart rate-limiting. The per-store rate limiter helps but the orchestrator should also cap simultaneous Playwright sessions across stores.
- Like all Instacart-based scrapers, results are zip-gated: without a zip the storefront defaults may show degraded results. Always pass zipCode.

## Routing follow-ups

Need a follow-up to wire `SCRAPER_RUNNER_STORE` keys for all 14 new chains in `index.js` / dispatch table. Same as called out in #76.