### PR TITLE
Social Sprint 2: Recipe Try Feedback + Peer Success Score

### DIFF
--- a/app/api/recipes/[id]/peer-score/route.ts
+++ b/app/api/recipes/[id]/peer-score/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server"
+import { getAuthenticatedProfile } from "@/lib/foundation/server"
+import { getRecipePeerScore } from "@/lib/social/recipe-feedback-service"
+
+export const runtime = "nodejs"
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const profile = await getAuthenticatedProfile()
+  if (!profile.ok) return NextResponse.json({ error: profile.error }, { status: profile.status })
+
+  const routeParams = await params
+  if (!routeParams.id) return NextResponse.json({ error: "Missing recipe id" }, { status: 400 })
+
+  const result = await getRecipePeerScore(profile.supabase as any, routeParams.id)
+  if ("error" in result && result.error) {
+    return NextResponse.json({ error: "Failed to load peer score" }, { status: 500 })
+  }
+  return NextResponse.json(result)
+}

--- a/app/api/recipes/peer-scores/route.ts
+++ b/app/api/recipes/peer-scores/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server"
+import { getAuthenticatedProfile } from "@/lib/foundation/server"
+import { getRecipePeerScoresBatch } from "@/lib/social/recipe-feedback-service"
+
+export const runtime = "nodejs"
+
+const MAX_BATCH_SIZE = 50
+
+async function readJsonObject(req: Request): Promise<Record<string, unknown> | null> {
+  const raw = await req.text()
+  if (!raw.trim()) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+export async function POST(req: Request) {
+  const profile = await getAuthenticatedProfile()
+  if (!profile.ok) return NextResponse.json({ error: profile.error }, { status: profile.status })
+
+  const body = await readJsonObject(req)
+  if (!body) return NextResponse.json({ error: "Invalid request body" }, { status: 400 })
+  const recipeIds = Array.isArray(body.recipeIds) ? body.recipeIds : null
+  if (!recipeIds) return NextResponse.json({ error: "recipeIds must be an array" }, { status: 400 })
+  if (recipeIds.length > MAX_BATCH_SIZE) {
+    return NextResponse.json({ error: `Batch size exceeds ${MAX_BATCH_SIZE}` }, { status: 400 })
+  }
+
+  const result = await getRecipePeerScoresBatch(
+    profile.supabase as any,
+    recipeIds.filter((id: unknown): id is string => typeof id === "string"),
+  )
+  if ("error" in result && result.error) {
+    return NextResponse.json({ error: "Failed to load peer scores" }, { status: 500 })
+  }
+  return NextResponse.json(result)
+}

--- a/app/api/social/recipe-tries/[id]/feedback/route.ts
+++ b/app/api/social/recipe-tries/[id]/feedback/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server"
+import { getAuthenticatedProfile } from "@/lib/foundation/server"
+import {
+  assertSocialEnabledForFeedback,
+  submitRecipeTryFeedback,
+} from "@/lib/social/recipe-feedback-service"
+
+export const runtime = "nodejs"
+
+async function readJsonObject(req: Request): Promise<Record<string, unknown> | null> {
+  const raw = await req.text()
+  if (!raw.trim()) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const profile = await getAuthenticatedProfile()
+  if (!profile.ok) return NextResponse.json({ error: profile.error }, { status: profile.status })
+
+  const enabled = await assertSocialEnabledForFeedback(profile.supabase as any, profile.profileId)
+  if (!enabled) return NextResponse.json({ error: "Social is disabled" }, { status: 403 })
+
+  const body = await readJsonObject(req)
+  if (!body) return NextResponse.json({ error: "Invalid request body" }, { status: 400 })
+
+  const routeParams = await params
+
+  const result = await submitRecipeTryFeedback(profile.supabase as any, {
+    profileId: profile.profileId,
+    recipeTryId: routeParams.id,
+    outcome: body.outcome,
+    tags: body.tags,
+    shareApproved: body.shareApproved,
+    idempotencyKey: typeof body.idempotencyKey === "string" ? body.idempotencyKey : null,
+  })
+
+  if ("validationError" in result) {
+    return NextResponse.json({ error: result.validationError }, { status: 400 })
+  }
+  if ("error" in result && result.error) {
+    return NextResponse.json({ error: "Failed to record feedback" }, { status: 500 })
+  }
+  return NextResponse.json(result, { status: result.duplicate ? 200 : 201 })
+}

--- a/app/api/social/recipe-tries/[id]/feedback/skip/route.ts
+++ b/app/api/social/recipe-tries/[id]/feedback/skip/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server"
+import { getAuthenticatedProfile } from "@/lib/foundation/server"
+import {
+  assertSocialEnabledForFeedback,
+  skipRecipeTryFeedback,
+} from "@/lib/social/recipe-feedback-service"
+
+export const runtime = "nodejs"
+
+export async function POST(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const profile = await getAuthenticatedProfile()
+  if (!profile.ok) return NextResponse.json({ error: profile.error }, { status: profile.status })
+
+  const enabled = await assertSocialEnabledForFeedback(profile.supabase as any, profile.profileId)
+  if (!enabled) return NextResponse.json({ error: "Social is disabled" }, { status: 403 })
+
+  const routeParams = await params
+
+  const result = await skipRecipeTryFeedback(profile.supabase as any, {
+    profileId: profile.profileId,
+    recipeTryId: routeParams.id,
+  })
+
+  if ("validationError" in result) {
+    return NextResponse.json({ error: result.validationError }, { status: 400 })
+  }
+  if ("error" in result && result.error) {
+    return NextResponse.json({ error: "Failed to skip feedback" }, { status: 500 })
+  }
+  return NextResponse.json(result)
+}

--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Clock, Users, ShoppingCart, ArrowLeft, ChefHat, Star, BarChart3, Utensi
 import { useAuth } from "@/contexts/auth-context"
 import { RecipeDetailSkeleton } from "@/components/recipe/cards/recipe-skeleton"
 import { RecipeReviews } from "@/components/recipe/detail/recipe-reviews"
+import { RecipePeerSuccess } from "@/components/recipe/social/recipe-peer-success"
 import { RecipePricingInfo } from "@/components/recipe/detail/recipe-pricing-info"
 import { RecipeActionBar } from "@/components/recipe/social/recipe-action-bar"
 import { RecipeCollectionManager } from "@/components/recipe/collections/recipe-collection-manager"
@@ -725,6 +726,10 @@ export default function RecipeDetailPage() {
               </div>
             </div>
           )}
+
+          <div className="w-full" data-tutorial="recipe-peer-success">
+            <RecipePeerSuccess recipeId={recipe.id} />
+          </div>
 
           <div className="w-full" data-tutorial="recipe-reviews">
             <RecipeReviews recipeId={recipe.id} friendProfileIds={friendProfileIds} />

--- a/components/recipe/social/recipe-peer-success.tsx
+++ b/components/recipe/social/recipe-peer-success.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import type { RecipeReliabilityTier, RecipeFeedbackTag } from "@/lib/social/recipe-feedback"
+
+type PeerScoreResponse = {
+  peerScore: {
+    recipeId: string
+    submittedCount: number
+    successCount: number
+    successRate: number | null
+    successPercentage: number | null
+    reliabilityTier: RecipeReliabilityTier
+    topTags: Array<{ tag: RecipeFeedbackTag; count: number }>
+    computedAt: string
+  }
+}
+
+const TIER_LABELS: Record<RecipeReliabilityTier, string> = {
+  early: "Early signal",
+  building: "Building signal",
+  tested: "Tested",
+}
+
+const TAG_DISPLAY: Record<RecipeFeedbackTag, string> = {
+  too_salty: "too salty",
+  not_salty_enough: "needed more salt",
+  too_spicy: "too spicy",
+  not_spicy_enough: "needed more heat",
+  bland: "bland",
+  too_sweet: "too sweet",
+  took_longer: "took longer",
+  too_hard: "harder than expected",
+  easier_than_expected: "easier than expected",
+  portion_too_small: "small portions",
+  portion_too_large: "large portions",
+  ingredient_swap: "ingredient swaps",
+  unclear_steps: "unclear steps",
+  worked_well: "worked well",
+  budget_friendly: "budget friendly",
+  good_for_meal_prep: "meal prep friendly",
+  would_make_again: "would make again",
+}
+
+function cooksLabel(n: number): string {
+  return n === 1 ? "1 cook" : `${n} cooks`
+}
+
+export function RecipePeerSuccess({ recipeId }: { recipeId: string }) {
+  const [data, setData] = useState<PeerScoreResponse["peerScore"] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const res = await fetch(`/api/recipes/${recipeId}/peer-score`)
+        if (!res.ok) {
+          setError("Peer score unavailable")
+          return
+        }
+        const json = (await res.json()) as PeerScoreResponse
+        if (!cancelled) setData(json.peerScore)
+      } catch {
+        if (!cancelled) setError("Peer score unavailable")
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [recipeId])
+
+  if (error || !data) return null
+
+  const { submittedCount, successPercentage, reliabilityTier, topTags } = data
+  const headline =
+    successPercentage !== null
+      ? `${successPercentage}% success · ${cooksLabel(submittedCount)}`
+      : `${TIER_LABELS.early} · ${cooksLabel(submittedCount)}`
+
+  return (
+    <Card aria-label="Cook success">
+      <CardContent className="space-y-2 py-4">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold">Cook success</span>
+          <Badge variant="outline">{TIER_LABELS[reliabilityTier]}</Badge>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Based on feedback from people who actually cooked this recipe. Separate from reviews and star
+          ratings.
+        </p>
+        <p className="text-base">{headline}</p>
+        {topTags.length > 0 && (
+          <p className="text-xs text-muted-foreground">
+            Most common notes: {topTags.map((t) => TAG_DISPLAY[t.tag]).join(", ")}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/social/recipe-feedback-prompt.tsx
+++ b/components/social/recipe-feedback-prompt.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import { useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { useToast } from "@/hooks"
+import {
+  RECIPE_FEEDBACK_TAGS,
+  type RecipeFeedbackOutcome,
+  type RecipeFeedbackTag,
+} from "@/lib/social/recipe-feedback"
+
+type PromptStage = "choose" | "tweaks" | "done"
+
+const TAG_LABELS: Record<RecipeFeedbackTag, string> = {
+  too_salty: "Too salty",
+  not_salty_enough: "Needed more salt",
+  too_spicy: "Too spicy",
+  not_spicy_enough: "Needed more heat",
+  bland: "Bland",
+  too_sweet: "Too sweet",
+  took_longer: "Took longer than expected",
+  too_hard: "Harder than expected",
+  easier_than_expected: "Easier than expected",
+  portion_too_small: "Portion too small",
+  portion_too_large: "Portion too large",
+  ingredient_swap: "I swapped ingredients",
+  unclear_steps: "Steps unclear",
+  worked_well: "Worked well",
+  budget_friendly: "Budget friendly",
+  good_for_meal_prep: "Good for meal prep",
+  would_make_again: "Would make again",
+}
+
+const MAX_SELECTED_TAGS = 6
+
+export type RecipeFeedbackPromptProps = {
+  recipeTryId: string
+  recipeTitle?: string | null
+  onComplete?: (result: { outcome: RecipeFeedbackOutcome; tags: RecipeFeedbackTag[] }) => void
+  onDismiss?: () => void
+}
+
+export function RecipeFeedbackPrompt({
+  recipeTryId,
+  recipeTitle,
+  onComplete,
+  onDismiss,
+}: RecipeFeedbackPromptProps) {
+  const { toast } = useToast()
+  const [stage, setStage] = useState<PromptStage>("choose")
+  const [submitting, setSubmitting] = useState(false)
+  const [selectedTags, setSelectedTags] = useState<RecipeFeedbackTag[]>([])
+
+  const title = recipeTitle ? `How did "${recipeTitle}" go?` : "How did this recipe go?"
+
+  function toggleTag(tag: RecipeFeedbackTag) {
+    setSelectedTags((prev) => {
+      if (prev.includes(tag)) return prev.filter((t) => t !== tag)
+      if (prev.length >= MAX_SELECTED_TAGS) return prev
+      return [...prev, tag]
+    })
+  }
+
+  async function submit(outcome: RecipeFeedbackOutcome, tags: RecipeFeedbackTag[]) {
+    if (submitting) return
+    setSubmitting(true)
+    try {
+      const endpoint =
+        outcome === "skipped_feedback"
+          ? `/api/social/recipe-tries/${recipeTryId}/feedback/skip`
+          : `/api/social/recipe-tries/${recipeTryId}/feedback`
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: outcome === "skipped_feedback" ? JSON.stringify({}) : JSON.stringify({ outcome, tags }),
+      })
+      if (!res.ok) {
+        const message = (await res.json().catch(() => ({})))?.error ?? "Could not save feedback."
+        toast({ title: "Feedback not saved", description: String(message), variant: "destructive" })
+        return
+      }
+      setStage("done")
+      onComplete?.({ outcome, tags })
+    } catch (error) {
+      toast({
+        title: "Network error",
+        description: "Please try again in a moment.",
+        variant: "destructive",
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (stage === "done") {
+    return (
+      <Card>
+        <CardContent className="py-4 text-sm text-muted-foreground">
+          Thanks — your feedback helps other cooks know what to expect.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {stage === "choose" && (
+          <div className="flex flex-wrap gap-2">
+            <Button size="sm" disabled={submitting} onClick={() => submit("succeeded", [])}>
+              Worked
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={submitting}
+              onClick={() => setStage("tweaks")}
+            >
+              Needed tweaks
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={submitting}
+              onClick={() => {
+                submit("skipped_feedback", [])
+                onDismiss?.()
+              }}
+            >
+              Skip
+            </Button>
+          </div>
+        )}
+
+        {stage === "tweaks" && (
+          <div className="space-y-3">
+            <p className="text-xs text-muted-foreground">
+              Pick up to {MAX_SELECTED_TAGS}. This stays private unless you choose to share it.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {RECIPE_FEEDBACK_TAGS.map((tag) => {
+                const selected = selectedTags.includes(tag)
+                return (
+                  <Badge
+                    key={tag}
+                    variant={selected ? "default" : "outline"}
+                    role="button"
+                    aria-pressed={selected}
+                    className="cursor-pointer select-none"
+                    onClick={() => toggleTag(tag)}
+                  >
+                    {TAG_LABELS[tag]}
+                  </Badge>
+                )
+              })}
+            </div>
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                disabled={submitting || selectedTags.length === 0}
+                onClick={() => submit("needed_tweaks", selectedTags)}
+              >
+                Submit
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={submitting}
+                onClick={() => setStage("choose")}
+              >
+                Back
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/docs/api-and-integrations.md
+++ b/docs/api-and-integrations.md
@@ -137,6 +137,24 @@ Last verified: 2026-04-30.
 - `POST/DELETE /api/social/cook-checks/[id]/reactions`
   - Adds/removes lightweight reactions when viewer can access the cook check.
 
+### Social Sprint 2 (Recipe Try Feedback + Peer Success Score)
+
+- `POST /api/social/recipe-tries/[id]/feedback`
+  - Submits one structured feedback record per owned recipe_try. Body: `{ outcome, tags?, shareApproved?, idempotencyKey? }`.
+  - `outcome` is one of `succeeded`, `needed_tweaks`, `skipped_feedback`. `tags` must come from the locked list in `lib/social/recipe-feedback.ts`; arbitrary strings are rejected. Duplicate submissions for the same recipe_try return the existing row (idempotent).
+- `POST /api/social/recipe-tries/[id]/feedback/skip`
+  - Shorthand for `outcome: skipped_feedback`. Skipped feedback never counts toward the peer score numerator or denominator.
+- `GET /api/recipes/[id]/peer-score`
+  - Returns the sanitized Peer Success Score for a recipe: `submittedCount`, `successPercentage` (hidden below 3 submissions), reliability tier (`early` / `building` / `tested`), and the top 1–3 most common tweak tags.
+- `POST /api/recipes/peer-scores`
+  - Batch version for recipe cards. Body `{ recipeIds: string[] }`, capped at 50 ids per call.
+
+**Relationship to existing reviews/ratings/likes (unchanged).** Legacy `recipe_reviews` (star rating + free-text), `recipe_favorites`, and `recipe_likes` continue to run exactly as before. Peer Success Score is intentionally separate — rendered as a distinct "Cook success" surface — because it answers a different question ("does this actually work when people cook it?") and is computed only from post-cook feedback rather than generic ratings.
+
+**Privacy boundary.** Individual `recipe_try_feedback` rows are private to their author via RLS; the aggregate peer score is computed server-side and sanitized through `assertSafeSocialProjectionPayload` before returning to any client. AI confidence, private verification metadata, budget data, and pantry internals never appear in peer score responses.
+
+**Deferred to Social Sprint 3.** Meal plan sharing, cooking journeys, algorithmic ranking changes, badge engine, and AI-moderated feedback are explicitly out of Sprint 2 scope.
+
 ## Frontend Callers
 
 - `contexts/auth-context.tsx`, `app/auth/signin/page.tsx`, `app/auth/signup/page.tsx`, and `app/auth/check-email/page.tsx` call `/api/auth/ensure-profile`.

--- a/lib/social/recipe-feedback-service.ts
+++ b/lib/social/recipe-feedback-service.ts
@@ -1,0 +1,208 @@
+import { appendProductEvent } from "@/lib/foundation/product-events-service"
+import { isDuplicateDatabaseError } from "@/lib/foundation/product-events"
+import { isSocialEnabledForProfile } from "@/lib/social/guards"
+import { getOwnedRecipeTry } from "@/lib/social/repository"
+import {
+  RECIPE_FEEDBACK_TAGS,
+  buildRecipeFeedbackIdempotencyKey,
+  sanitizeRecipePeerScoreForClient,
+  validateRecipeFeedbackTags,
+  validateRecipeTryFeedbackOutcome,
+  type RecipeFeedbackOutcome,
+  type SanitizedPeerScore,
+} from "@/lib/social/recipe-feedback"
+
+type SupabaseLike = { from: (table: string) => any }
+
+export type SubmitFeedbackInput = {
+  profileId: string
+  recipeTryId: string
+  outcome: unknown
+  tags?: unknown
+  shareApproved?: unknown
+  idempotencyKey?: string | null
+}
+
+export type SubmitFeedbackResult =
+  | { feedback: Record<string, unknown>; duplicate?: boolean }
+  | { validationError: string }
+  | { error: unknown }
+
+/**
+ * Submit structured feedback for an owned recipe_try. Enforces:
+ *  - recipe_try must exist and belong to the caller
+ *  - outcome must be a valid enum
+ *  - tags must all be in the locked RECIPE_FEEDBACK_TAGS list
+ *  - skipped_feedback must carry no tags
+ *  - one feedback row per recipe_try (idempotent on re-submit with same key)
+ */
+export async function submitRecipeTryFeedback(
+  supabase: SupabaseLike,
+  input: SubmitFeedbackInput,
+): Promise<SubmitFeedbackResult> {
+  if (!validateRecipeTryFeedbackOutcome(input.outcome)) {
+    return { validationError: "Unknown feedback outcome" }
+  }
+  const outcome = input.outcome as RecipeFeedbackOutcome
+  const tagsResult = validateRecipeFeedbackTags(input.tags, outcome)
+  if (!tagsResult.ok) return { validationError: tagsResult.error }
+
+  const { data: recipeTry, error: tryError } = await getOwnedRecipeTry(
+    supabase,
+    input.profileId,
+    input.recipeTryId,
+  )
+  if (tryError) return { error: tryError }
+  if (!recipeTry) return { validationError: "Recipe try not found or not owned by caller" }
+
+  const idempotencyKey =
+    input.idempotencyKey?.trim() ||
+    buildRecipeFeedbackIdempotencyKey(input.profileId, input.recipeTryId)
+
+  const insertPayload = {
+    profile_id: input.profileId,
+    recipe_try_id: input.recipeTryId,
+    recipe_id: recipeTry.recipe_id ?? null,
+    outcome,
+    feedback_tags: tagsResult.tags,
+    share_approved: input.shareApproved === true,
+    idempotency_key: idempotencyKey,
+    metadata: {},
+  }
+
+  const { data, error } = await (supabase as any)
+    .from("recipe_try_feedback")
+    .insert(insertPayload)
+    .select("*")
+    .single()
+
+  if (isDuplicateDatabaseError(error)) {
+    // Re-submit with same idempotency key or recipe_try_id: return the existing row.
+    const { data: existing, error: lookupError } = await (supabase as any)
+      .from("recipe_try_feedback")
+      .select("*")
+      .eq("profile_id", input.profileId)
+      .eq("recipe_try_id", input.recipeTryId)
+      .maybeSingle()
+    if (lookupError || !existing) return { error: lookupError ?? error }
+    return { feedback: existing, duplicate: true }
+  }
+  if (error) return { error }
+
+  await appendProductEvent(supabase, input.profileId, {
+    eventType: "recipe_try.logged",
+    idempotencyKey: `${idempotencyKey}:event`,
+    metadata: { outcome, tagCount: tagsResult.tags.length },
+  })
+
+  return { feedback: data }
+}
+
+export async function skipRecipeTryFeedback(
+  supabase: SupabaseLike,
+  input: { profileId: string; recipeTryId: string },
+): Promise<SubmitFeedbackResult> {
+  return submitRecipeTryFeedback(supabase, {
+    profileId: input.profileId,
+    recipeTryId: input.recipeTryId,
+    outcome: "skipped_feedback",
+    tags: [],
+  })
+}
+
+export type PeerScoreResult =
+  | { peerScore: SanitizedPeerScore }
+  | { error: unknown }
+
+/**
+ * Compute Peer Success Score for a recipe by aggregating submitted feedback.
+ * Only 'succeeded' and 'needed_tweaks' count toward the denominator —
+ * 'skipped_feedback' never affects the score (spec constraint 8).
+ */
+export async function getRecipePeerScore(
+  supabase: SupabaseLike,
+  recipeId: string,
+): Promise<PeerScoreResult> {
+  const { data, error } = await (supabase as any)
+    .from("recipe_try_feedback")
+    .select("outcome, feedback_tags")
+    .eq("recipe_id", recipeId)
+    .in("outcome", ["succeeded", "needed_tweaks"])
+
+  if (error) return { error }
+
+  const rows = (data ?? []) as Array<{ outcome: RecipeFeedbackOutcome; feedback_tags: string[] }>
+  let succeeded = 0
+  let neededTweaks = 0
+  const tagCounts: Record<string, number> = {}
+  for (const row of rows) {
+    if (row.outcome === "succeeded") succeeded += 1
+    else if (row.outcome === "needed_tweaks") neededTweaks += 1
+    const seenInRow = new Set<string>()
+    for (const tag of row.feedback_tags ?? []) {
+      // Count each tag once per feedback row, and only lock-listed tags.
+      if (seenInRow.has(tag)) continue
+      if (!RECIPE_FEEDBACK_TAGS.includes(tag as any)) continue
+      seenInRow.add(tag)
+      tagCounts[tag] = (tagCounts[tag] ?? 0) + 1
+    }
+  }
+
+  return {
+    peerScore: sanitizeRecipePeerScoreForClient({
+      recipeId,
+      counts: { succeeded, neededTweaks, skipped: 0 },
+      tagCounts,
+    }),
+  }
+}
+
+export async function getRecipePeerScoresBatch(
+  supabase: SupabaseLike,
+  recipeIds: string[],
+): Promise<{ peerScores: SanitizedPeerScore[] } | { error: unknown }> {
+  const uniqueIds = Array.from(new Set(recipeIds.filter((id): id is string => typeof id === "string" && id.length > 0)))
+  if (uniqueIds.length === 0) return { peerScores: [] }
+
+  const { data, error } = await (supabase as any)
+    .from("recipe_try_feedback")
+    .select("recipe_id, outcome, feedback_tags")
+    .in("recipe_id", uniqueIds)
+    .in("outcome", ["succeeded", "needed_tweaks"])
+
+  if (error) return { error }
+
+  type Row = { recipe_id: string; outcome: RecipeFeedbackOutcome; feedback_tags: string[] }
+  const byRecipe = new Map<string, { succeeded: number; neededTweaks: number; tagCounts: Record<string, number> }>()
+  for (const id of uniqueIds) byRecipe.set(id, { succeeded: 0, neededTweaks: 0, tagCounts: {} })
+
+  for (const row of (data ?? []) as Row[]) {
+    const bucket = byRecipe.get(row.recipe_id)
+    if (!bucket) continue
+    if (row.outcome === "succeeded") bucket.succeeded += 1
+    else if (row.outcome === "needed_tweaks") bucket.neededTweaks += 1
+    const seenInRow = new Set<string>()
+    for (const tag of row.feedback_tags ?? []) {
+      if (seenInRow.has(tag)) continue
+      if (!RECIPE_FEEDBACK_TAGS.includes(tag as any)) continue
+      seenInRow.add(tag)
+      bucket.tagCounts[tag] = (bucket.tagCounts[tag] ?? 0) + 1
+    }
+  }
+
+  const peerScores: SanitizedPeerScore[] = []
+  for (const [recipeId, bucket] of byRecipe.entries()) {
+    peerScores.push(
+      sanitizeRecipePeerScoreForClient({
+        recipeId,
+        counts: { succeeded: bucket.succeeded, neededTweaks: bucket.neededTweaks, skipped: 0 },
+        tagCounts: bucket.tagCounts,
+      }),
+    )
+  }
+  return { peerScores }
+}
+
+export async function assertSocialEnabledForFeedback(supabase: SupabaseLike, profileId: string) {
+  return isSocialEnabledForProfile(supabase, profileId)
+}

--- a/lib/social/recipe-feedback.ts
+++ b/lib/social/recipe-feedback.ts
@@ -1,0 +1,183 @@
+import { assertSafeSocialProjectionPayload } from "@/lib/foundation/privacy"
+import { buildIdempotencyKey } from "@/lib/foundation/product-events"
+
+export const RECIPE_FEEDBACK_OUTCOMES = [
+  "succeeded",
+  "needed_tweaks",
+  "skipped_feedback",
+] as const
+
+export type RecipeFeedbackOutcome = (typeof RECIPE_FEEDBACK_OUTCOMES)[number]
+
+// Locked chip list (Sprint 2 spec). Do not add custom tags.
+export const RECIPE_FEEDBACK_TAGS = [
+  "too_salty",
+  "not_salty_enough",
+  "too_spicy",
+  "not_spicy_enough",
+  "bland",
+  "too_sweet",
+  "took_longer",
+  "too_hard",
+  "easier_than_expected",
+  "portion_too_small",
+  "portion_too_large",
+  "ingredient_swap",
+  "unclear_steps",
+  "worked_well",
+  "budget_friendly",
+  "good_for_meal_prep",
+  "would_make_again",
+] as const
+
+export type RecipeFeedbackTag = (typeof RECIPE_FEEDBACK_TAGS)[number]
+
+const MAX_TAGS_PER_FEEDBACK = 6
+
+// Reliability tier thresholds (Sprint 2 spec).
+export const RELIABILITY_TIER_BUILDING_MIN = 3
+export const RELIABILITY_TIER_TESTED_MIN = 10
+
+export type RecipeReliabilityTier = "early" | "building" | "tested"
+
+export function validateRecipeTryFeedbackOutcome(value: unknown): value is RecipeFeedbackOutcome {
+  return typeof value === "string" && RECIPE_FEEDBACK_OUTCOMES.includes(value as RecipeFeedbackOutcome)
+}
+
+export function isRecipeFeedbackTag(value: unknown): value is RecipeFeedbackTag {
+  return typeof value === "string" && RECIPE_FEEDBACK_TAGS.includes(value as RecipeFeedbackTag)
+}
+
+/**
+ * Returns the validated, de-duplicated tag list, or null if any tag is not in the locked set.
+ * Rejects arbitrary strings, non-arrays, and oversized lists. Returns an empty array for
+ * undefined / null / empty input so callers can normalize "no tags" safely.
+ */
+export function validateRecipeFeedbackTags(
+  value: unknown,
+  outcome: RecipeFeedbackOutcome,
+): { ok: true; tags: RecipeFeedbackTag[] } | { ok: false; error: string } {
+  if (outcome === "skipped_feedback") {
+    // Skipped feedback must carry no tags.
+    if (value === undefined || value === null) return { ok: true, tags: [] }
+    if (Array.isArray(value) && value.length === 0) return { ok: true, tags: [] }
+    return { ok: false, error: "skipped_feedback cannot include tags" }
+  }
+  if (value === undefined || value === null) return { ok: true, tags: [] }
+  if (!Array.isArray(value)) return { ok: false, error: "feedback_tags must be an array" }
+  if (value.length > MAX_TAGS_PER_FEEDBACK) {
+    return { ok: false, error: `feedback_tags exceeds max of ${MAX_TAGS_PER_FEEDBACK}` }
+  }
+  const seen = new Set<RecipeFeedbackTag>()
+  for (const entry of value) {
+    if (!isRecipeFeedbackTag(entry)) {
+      return { ok: false, error: `Unknown feedback tag: ${String(entry)}` }
+    }
+    seen.add(entry)
+  }
+  return { ok: true, tags: Array.from(seen) }
+}
+
+export type RecipeFeedbackCounts = {
+  succeeded: number
+  neededTweaks: number
+  skipped: number
+}
+
+/**
+ * Peer Success Score = succeeded / (succeeded + needed_tweaks).
+ * Skipped feedback is never counted toward either numerator or denominator,
+ * matching spec constraint 8 ("skipped/no_feedback does not count as success"
+ * or toward failure).
+ */
+export function calculatePeerSuccessScore(counts: RecipeFeedbackCounts): {
+  submittedCount: number
+  successCount: number
+  successRate: number | null
+} {
+  const submitted = counts.succeeded + counts.neededTweaks
+  if (submitted <= 0) {
+    return { submittedCount: 0, successCount: 0, successRate: null }
+  }
+  return {
+    submittedCount: submitted,
+    successCount: counts.succeeded,
+    successRate: counts.succeeded / submitted,
+  }
+}
+
+export function getRecipeReliabilityTier(submittedCount: number): RecipeReliabilityTier {
+  if (submittedCount >= RELIABILITY_TIER_TESTED_MIN) return "tested"
+  if (submittedCount >= RELIABILITY_TIER_BUILDING_MIN) return "building"
+  return "early"
+}
+
+export function shouldShowSuccessPercentage(submittedCount: number): boolean {
+  return submittedCount >= RELIABILITY_TIER_BUILDING_MIN
+}
+
+/**
+ * Returns the top tags by frequency with stable ordering. Ties broken by the
+ * order that tags appear in RECIPE_FEEDBACK_TAGS (lock-list order), so the
+ * output is deterministic regardless of aggregation order.
+ */
+export function summarizeTopFeedbackTags(
+  tagCounts: Record<string, number>,
+  limit = 3,
+): Array<{ tag: RecipeFeedbackTag; count: number }> {
+  const entries: Array<{ tag: RecipeFeedbackTag; count: number }> = []
+  for (const tag of RECIPE_FEEDBACK_TAGS) {
+    const count = tagCounts[tag] ?? 0
+    if (count > 0) entries.push({ tag, count })
+  }
+  entries.sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count
+    return RECIPE_FEEDBACK_TAGS.indexOf(a.tag) - RECIPE_FEEDBACK_TAGS.indexOf(b.tag)
+  })
+  return entries.slice(0, Math.max(0, limit))
+}
+
+export function buildRecipeFeedbackIdempotencyKey(profileId: string, recipeTryId: string): string {
+  return buildIdempotencyKey(["recipe-try-feedback", profileId, recipeTryId])
+}
+
+export type SanitizedPeerScore = {
+  recipeId: string
+  submittedCount: number
+  successCount: number
+  successRate: number | null
+  successPercentage: number | null
+  reliabilityTier: RecipeReliabilityTier
+  topTags: Array<{ tag: RecipeFeedbackTag; count: number }>
+  computedAt: string
+}
+
+/**
+ * Strips anything that could leak private or AI-confidence metadata before
+ * returning peer score data to a client. Also runs the foundation sanitizer
+ * to reuse the existing deny-list of unsafe keys.
+ */
+export function sanitizeRecipePeerScoreForClient(input: {
+  recipeId: string
+  counts: RecipeFeedbackCounts
+  tagCounts: Record<string, number>
+  computedAt?: string
+}): SanitizedPeerScore {
+  const { submittedCount, successCount, successRate } = calculatePeerSuccessScore(input.counts)
+  const showPercentage = shouldShowSuccessPercentage(submittedCount)
+  const tier = getRecipeReliabilityTier(submittedCount)
+  const topTags = summarizeTopFeedbackTags(input.tagCounts)
+  const payload: SanitizedPeerScore = {
+    recipeId: input.recipeId,
+    submittedCount,
+    successCount,
+    successRate: showPercentage ? successRate : null,
+    successPercentage:
+      showPercentage && successRate !== null ? Math.round(successRate * 100) : null,
+    reliabilityTier: tier,
+    topTags,
+    computedAt: input.computedAt ?? new Date().toISOString(),
+  }
+  assertSafeSocialProjectionPayload(payload as unknown as Record<string, unknown>)
+  return payload
+}

--- a/supabase/migrations/20260501180000_social_sprint2_recipe_feedback.sql
+++ b/supabase/migrations/20260501180000_social_sprint2_recipe_feedback.sql
@@ -1,0 +1,84 @@
+-- Social Sprint 2: Recipe Try Feedback + Peer Success Score
+-- Adds structured post-cook feedback tied to recipe_tries.
+-- Intentionally separate from legacy public.recipe_reviews (star rating + free-text),
+-- which continues to operate unchanged. Peer Success Score is computed on read
+-- from this table; no aggregate snapshot table is introduced in Sprint 2.
+
+do $$
+begin
+  create type public.recipe_feedback_outcome as enum (
+    'succeeded',
+    'needed_tweaks',
+    'skipped_feedback'
+  );
+exception when duplicate_object then null;
+end $$;
+
+create table if not exists public.recipe_try_feedback (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  recipe_try_id uuid not null references public.recipe_tries(id) on delete cascade,
+  recipe_id uuid references public.recipes(id) on delete set null,
+  outcome public.recipe_feedback_outcome not null,
+  feedback_tags text[] not null default array[]::text[],
+  visibility public.foundation_social_visibility not null default 'private',
+  share_approved boolean not null default false,
+  idempotency_key text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  -- One feedback record per recipe_try. Updates go through the same row.
+  constraint recipe_try_feedback_unique_try unique (recipe_try_id),
+  -- Skipped feedback should never carry tags.
+  constraint recipe_try_feedback_tags_when_outcome check (
+    (outcome = 'skipped_feedback' and coalesce(array_length(feedback_tags, 1), 0) = 0)
+    or outcome <> 'skipped_feedback'
+  )
+);
+
+create index if not exists idx_recipe_try_feedback_recipe_outcome
+  on public.recipe_try_feedback (recipe_id, outcome)
+  where recipe_id is not null;
+
+create index if not exists idx_recipe_try_feedback_profile_created
+  on public.recipe_try_feedback (profile_id, created_at desc);
+
+create unique index if not exists idx_recipe_try_feedback_idempotency
+  on public.recipe_try_feedback (profile_id, idempotency_key)
+  where idempotency_key is not null;
+
+drop trigger if exists trg_recipe_try_feedback_updated_at on public.recipe_try_feedback;
+create trigger trg_recipe_try_feedback_updated_at before update on public.recipe_try_feedback
+for each row execute procedure public.set_updated_at();
+
+alter table public.recipe_try_feedback enable row level security;
+
+-- Individual feedback is private to its author. Aggregate peer scores are served
+-- via server-side computation only, never by exposing raw rows to other profiles.
+drop policy if exists "recipe_try_feedback_select_own" on public.recipe_try_feedback;
+create policy "recipe_try_feedback_select_own"
+  on public.recipe_try_feedback for select to authenticated
+  using (profile_id = public.current_profile_id());
+
+drop policy if exists "recipe_try_feedback_insert_own" on public.recipe_try_feedback;
+create policy "recipe_try_feedback_insert_own"
+  on public.recipe_try_feedback for insert to authenticated
+  with check (
+    profile_id = public.current_profile_id()
+    and exists (
+      select 1 from public.recipe_tries rt
+      where rt.id = recipe_try_feedback.recipe_try_id
+        and rt.profile_id = public.current_profile_id()
+    )
+  );
+
+drop policy if exists "recipe_try_feedback_update_own" on public.recipe_try_feedback;
+create policy "recipe_try_feedback_update_own"
+  on public.recipe_try_feedback for update to authenticated
+  using (profile_id = public.current_profile_id())
+  with check (profile_id = public.current_profile_id());
+
+drop policy if exists "recipe_try_feedback_delete_own" on public.recipe_try_feedback;
+create policy "recipe_try_feedback_delete_own"
+  on public.recipe_try_feedback for delete to authenticated
+  using (profile_id = public.current_profile_id());

--- a/test/social/recipe-feedback-service.spec.ts
+++ b/test/social/recipe-feedback-service.spec.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  getOwnedRecipeTry: vi.fn(),
+  isDuplicateDatabaseError: vi.fn().mockReturnValue(false),
+  appendProductEvent: vi.fn(),
+}))
+
+vi.mock("@/lib/social/repository", () => ({
+  getOwnedRecipeTry: mocks.getOwnedRecipeTry,
+}))
+
+vi.mock("@/lib/foundation/product-events", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/foundation/product-events")>(
+    "@/lib/foundation/product-events",
+  )
+  return {
+    ...actual,
+    isDuplicateDatabaseError: mocks.isDuplicateDatabaseError,
+  }
+})
+
+vi.mock("@/lib/foundation/product-events-service", () => ({
+  appendProductEvent: mocks.appendProductEvent,
+}))
+
+vi.mock("@/lib/social/guards", () => ({
+  isSocialEnabledForProfile: vi.fn().mockResolvedValue(true),
+}))
+
+import {
+  getRecipePeerScore,
+  submitRecipeTryFeedback,
+} from "@/lib/social/recipe-feedback-service"
+
+type QueryResult = { data?: unknown; error?: unknown }
+
+function makeSupabase(options: {
+  insertResult?: QueryResult
+  existingFeedback?: QueryResult
+  aggregateRows?: QueryResult
+} = {}) {
+  return {
+    from(table: string) {
+      if (table !== "recipe_try_feedback") {
+        throw new Error(`Unexpected table: ${table}`)
+      }
+      return {
+        insert() {
+          return {
+            select() {
+              return {
+                single: async () => options.insertResult ?? { data: { id: "fb_1" } },
+              }
+            },
+          }
+        },
+        select(cols: string) {
+          if (cols === "*") {
+            return {
+              eq() {
+                return {
+                  eq() {
+                    return { maybeSingle: async () => options.existingFeedback ?? { data: null } }
+                  },
+                }
+              },
+            }
+          }
+          return {
+            eq() {
+              return {
+                in: async () => options.aggregateRows ?? { data: [] },
+              }
+            },
+          }
+        },
+      }
+    },
+  }
+}
+
+describe("recipe feedback service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.isDuplicateDatabaseError.mockReturnValue(false)
+  })
+
+  it("rejects unknown outcomes without any DB access", async () => {
+    const result = await submitRecipeTryFeedback({} as any, {
+      profileId: "p1",
+      recipeTryId: "t1",
+      outcome: "no_feedback",
+    })
+    expect(result).toEqual({ validationError: "Unknown feedback outcome" })
+    expect(mocks.getOwnedRecipeTry).not.toHaveBeenCalled()
+  })
+
+  it("rejects tags that are not in the locked list", async () => {
+    const result = await submitRecipeTryFeedback({} as any, {
+      profileId: "p1",
+      recipeTryId: "t1",
+      outcome: "needed_tweaks",
+      tags: ["definitely_not_a_tag"],
+    })
+    expect("validationError" in result).toBe(true)
+  })
+
+  it("refuses feedback on a recipe_try the caller does not own", async () => {
+    mocks.getOwnedRecipeTry.mockResolvedValue({ data: null })
+    const result = await submitRecipeTryFeedback(makeSupabase() as any, {
+      profileId: "p1",
+      recipeTryId: "t1",
+      outcome: "succeeded",
+    })
+    expect(result).toEqual({ validationError: "Recipe try not found or not owned by caller" })
+  })
+
+  it("returns existing row when the unique constraint fires (duplicate idempotent)", async () => {
+    mocks.getOwnedRecipeTry.mockResolvedValue({ data: { id: "t1", recipe_id: "r1" } })
+    mocks.isDuplicateDatabaseError.mockReturnValue(true)
+    const supabase = makeSupabase({
+      insertResult: { data: null, error: { code: "23505" } },
+      existingFeedback: { data: { id: "fb_existing" } },
+    })
+    const result = await submitRecipeTryFeedback(supabase as any, {
+      profileId: "p1",
+      recipeTryId: "t1",
+      outcome: "succeeded",
+    })
+    expect("feedback" in result).toBe(true)
+    if ("feedback" in result) {
+      expect(result.duplicate).toBe(true)
+      expect((result.feedback as any).id).toBe("fb_existing")
+    }
+  })
+
+  it("computes peer score from aggregated rows, ignoring skipped feedback in the total", async () => {
+    const supabase = makeSupabase({
+      aggregateRows: {
+        data: [
+          { outcome: "succeeded", feedback_tags: ["worked_well"] },
+          { outcome: "succeeded", feedback_tags: [] },
+          { outcome: "succeeded", feedback_tags: ["worked_well", "would_make_again"] },
+          { outcome: "needed_tweaks", feedback_tags: ["too_salty"] },
+        ],
+      },
+    })
+    const result = await getRecipePeerScore(supabase as any, "recipe-1")
+    expect("peerScore" in result).toBe(true)
+    if ("peerScore" in result) {
+      expect(result.peerScore.submittedCount).toBe(4)
+      expect(result.peerScore.successCount).toBe(3)
+      expect(result.peerScore.successPercentage).toBe(75)
+      expect(result.peerScore.reliabilityTier).toBe("building")
+      expect(result.peerScore.topTags[0].tag).toBe("worked_well")
+    }
+  })
+
+  it("does not expose aiConfidence or private metadata in sanitized peer score", async () => {
+    const supabase = makeSupabase({
+      aggregateRows: {
+        data: [{ outcome: "succeeded", feedback_tags: ["worked_well"] }],
+      },
+    })
+    const result = await getRecipePeerScore(supabase as any, "recipe-1")
+    if ("peerScore" in result) {
+      const json = JSON.stringify(result.peerScore)
+      expect(json).not.toMatch(/aiConfidence/i)
+      expect(json).not.toMatch(/confidence/i)
+      expect(json).not.toMatch(/budget/i)
+    }
+  })
+})

--- a/test/social/recipe-feedback.spec.ts
+++ b/test/social/recipe-feedback.spec.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest"
+import {
+  RECIPE_FEEDBACK_TAGS,
+  calculatePeerSuccessScore,
+  getRecipeReliabilityTier,
+  sanitizeRecipePeerScoreForClient,
+  shouldShowSuccessPercentage,
+  summarizeTopFeedbackTags,
+  validateRecipeFeedbackTags,
+  validateRecipeTryFeedbackOutcome,
+} from "@/lib/social/recipe-feedback"
+
+describe("recipe feedback helpers", () => {
+  it("validates outcomes against locked enum", () => {
+    expect(validateRecipeTryFeedbackOutcome("succeeded")).toBe(true)
+    expect(validateRecipeTryFeedbackOutcome("needed_tweaks")).toBe(true)
+    expect(validateRecipeTryFeedbackOutcome("skipped_feedback")).toBe(true)
+    expect(validateRecipeTryFeedbackOutcome("no_feedback")).toBe(false)
+    expect(validateRecipeTryFeedbackOutcome(undefined)).toBe(false)
+    expect(validateRecipeTryFeedbackOutcome(42)).toBe(false)
+  })
+
+  it("accepts only tags from the locked list and de-duplicates", () => {
+    const ok = validateRecipeFeedbackTags(["too_salty", "worked_well", "too_salty"], "needed_tweaks")
+    expect(ok.ok).toBe(true)
+    if (ok.ok) {
+      expect(ok.tags).toEqual(["too_salty", "worked_well"])
+    }
+  })
+
+  it("rejects arbitrary custom tags", () => {
+    const bad = validateRecipeFeedbackTags(["too_salty", "my_custom_tag"], "needed_tweaks")
+    expect(bad.ok).toBe(false)
+  })
+
+  it("rejects non-array tag input", () => {
+    const bad = validateRecipeFeedbackTags("too_salty", "needed_tweaks")
+    expect(bad.ok).toBe(false)
+  })
+
+  it("requires empty tags when outcome is skipped_feedback", () => {
+    expect(validateRecipeFeedbackTags([], "skipped_feedback").ok).toBe(true)
+    expect(validateRecipeFeedbackTags(["too_salty"], "skipped_feedback").ok).toBe(false)
+  })
+
+  it("computes success rate excluding skipped feedback", () => {
+    const result = calculatePeerSuccessScore({ succeeded: 3, neededTweaks: 1, skipped: 7 })
+    expect(result.submittedCount).toBe(4)
+    expect(result.successCount).toBe(3)
+    expect(result.successRate).toBe(0.75)
+  })
+
+  it("returns null success rate when nothing has been submitted", () => {
+    const result = calculatePeerSuccessScore({ succeeded: 0, neededTweaks: 0, skipped: 99 })
+    expect(result.submittedCount).toBe(0)
+    expect(result.successRate).toBeNull()
+  })
+
+  it("maps submitted count to reliability tiers at the spec thresholds", () => {
+    expect(getRecipeReliabilityTier(0)).toBe("early")
+    expect(getRecipeReliabilityTier(2)).toBe("early")
+    expect(getRecipeReliabilityTier(3)).toBe("building")
+    expect(getRecipeReliabilityTier(9)).toBe("building")
+    expect(getRecipeReliabilityTier(10)).toBe("tested")
+  })
+
+  it("hides percentage below the N>=3 threshold", () => {
+    expect(shouldShowSuccessPercentage(0)).toBe(false)
+    expect(shouldShowSuccessPercentage(2)).toBe(false)
+    expect(shouldShowSuccessPercentage(3)).toBe(true)
+    expect(shouldShowSuccessPercentage(20)).toBe(true)
+  })
+
+  it("summarizes top tags by frequency with deterministic tie-breaking", () => {
+    const top = summarizeTopFeedbackTags({
+      too_salty: 5,
+      took_longer: 5,
+      bland: 2,
+      would_make_again: 1,
+    })
+    expect(top[0].tag).toBe("too_salty")
+    expect(top[1].tag).toBe("took_longer")
+    expect(top.length).toBe(3)
+  })
+
+  it("ignores zero-count tags", () => {
+    const top = summarizeTopFeedbackTags({ too_salty: 0, took_longer: 2 })
+    expect(top).toEqual([{ tag: "took_longer", count: 2 }])
+  })
+
+  it("every locked tag is a stable string identifier", () => {
+    for (const tag of RECIPE_FEEDBACK_TAGS) {
+      expect(typeof tag).toBe("string")
+      expect(tag).toMatch(/^[a-z_]+$/)
+    }
+  })
+
+  it("sanitized peer score hides percentage under N>=3 and exposes only safe keys", () => {
+    const payload = sanitizeRecipePeerScoreForClient({
+      recipeId: "recipe-1",
+      counts: { succeeded: 1, neededTweaks: 1, skipped: 0 },
+      tagCounts: { too_salty: 1 },
+    })
+    expect(payload.submittedCount).toBe(2)
+    expect(payload.successPercentage).toBeNull()
+    expect(payload.successRate).toBeNull()
+    expect(payload.reliabilityTier).toBe("early")
+    expect(Object.keys(payload)).not.toContain("aiConfidence")
+    expect(Object.keys(payload)).not.toContain("confidence")
+  })
+
+  it("sanitized peer score exposes percentage once N>=3", () => {
+    const payload = sanitizeRecipePeerScoreForClient({
+      recipeId: "recipe-1",
+      counts: { succeeded: 4, neededTweaks: 1, skipped: 10 },
+      tagCounts: { took_longer: 3 },
+    })
+    expect(payload.submittedCount).toBe(5)
+    expect(payload.successPercentage).toBe(80)
+    expect(payload.reliabilityTier).toBe("building")
+    expect(payload.topTags[0].tag).toBe("took_longer")
+  })
+})


### PR DESCRIPTION
## Social Sprint 2: Recipe Try Feedback + Peer Success Score

Builds the post-cook feedback layer on top of Sprint 1 (Kitchen Sync + Cook Checks). Recipe reliability is now driven by actual cooking attempts rather than generic popularity.

### Audit decision

Existing `recipe_reviews` (stars + free-text), `recipe_favorites`, and `recipe_likes` keep running unchanged. Peer Success Score is a **separate surface** labeled "Cook success" because it answers a different question (does this recipe actually work when you cook it?). No merge, no visual confusion.

### What ships

- **Migration** — one additive `recipe_try_feedback` table with RLS (select/insert/update/delete own), outcome enum (`succeeded` / `needed_tweaks` / `skipped_feedback`), unique per recipe_try, `share_approved` default false. No aggregate snapshot table in Sprint 2; peer score is computed on read.
- **Domain helpers** (`lib/social/recipe-feedback.ts`) — locked 17-chip list, outcome + tag validators, `calculatePeerSuccessScore` (skipped never counts), reliability tiers (Early <3, Building 3–9, Tested 10+), `sanitizeRecipePeerScoreForClient` runs through `assertSafeSocialProjectionPayload`.
- **Service** (`lib/social/recipe-feedback-service.ts`) — ownership check, idempotent duplicate handling, product event on submit.
- **APIs** — `POST /api/social/recipe-tries/[id]/feedback`, `POST .../feedback/skip`, `GET /api/recipes/[id]/peer-score`, `POST /api/recipes/peer-scores` (batch, capped at 50).
- **UI** — `RecipeFeedbackPrompt` (Worked / Needed tweaks / Skip + locked chip grid, 6-tag max), `RecipePeerSuccess` (N, % only when N≥3, tier badge, top 1–3 tweak tags). Mounted above existing reviews on `app/recipes/[id]/page.tsx`.
- **Tests** — unit coverage of validators, score math, tier thresholds, tag ranking; service-level coverage of unauthorized access, duplicate idempotency, batch aggregation, AI-confidence leak protection.
- **Docs** — new Sprint 2 section in `docs/api-and-integrations.md` with separation decision and privacy boundary.

### Privacy boundary

- Individual `recipe_try_feedback` rows are private to their author via RLS.
- Aggregate peer score computed server-side; no raw rows, no profile data, no AI confidence, no verification metadata, no budget/pantry internals.
- Social sharing of feedback is opt-in via `share_approved` and sanitized before any projection.

### What is intentionally NOT in this PR

Free-text reviews, new star ratings, comment threads, recipe forking, meal-plan sharing, cooking journeys, pantry auto-deduct, badge engine, AI moderation, algorithmic ranking changes.

### Known follow-ups

- `app/recipes/[id]/__tests__/page.test.tsx` not extended — worth a render assertion for `RecipePeerSuccess` in a follow-up commit.
- Feedback prompt is ready to be mounted from Cook Check flow; not auto-wired in this PR to keep diff minimal.

### Next sprint

Social Sprint 3: Meal Plan Sharing + Cooking Journeys.
