### PR TITLE
[codex] Add privacy consent baseline

### DIFF
--- a/app/api/budget/goals/route.ts
+++ b/app/api/budget/goals/route.ts
@@ -61,7 +61,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Failed to create budget goal" }, { status: 500 })
     }
 
-    getPostHogClient().capture({
+    getPostHogClient(req.headers.get("cookie")).capture({
       distinctId: profile.profileId,
       event: "budget_goal_created",
       properties: { category, target_cents: targetCents },

--- a/app/api/budget/goals/switch/route.ts
+++ b/app/api/budget/goals/switch/route.ts
@@ -59,7 +59,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Failed to switch goal" }, { status: 500 })
     }
 
-    getPostHogClient().capture({
+    getPostHogClient(req.headers.get("cookie")).capture({
       distinctId: profile.profileId,
       event: "budget_goal_switched",
       properties: { goal_id: result.goal.id, previous_goal_id: result.previousGoalId },

--- a/app/api/budget/spend/route.ts
+++ b/app/api/budget/spend/route.ts
@@ -60,7 +60,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Failed to log spend" }, { status: 500 })
     }
 
-    getPostHogClient().capture({
+    getPostHogClient(req.headers.get("cookie")).capture({
       distinctId: profile.profileId,
       event: "budget_spend_logged",
       properties: { source_type: sourceType, amount_cents: amountCents, duplicate: result.duplicate ?? false },

--- a/app/api/budget/weeks/[weekStart]/allocate/route.ts
+++ b/app/api/budget/weeks/[weekStart]/allocate/route.ts
@@ -52,7 +52,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ weekSta
       return NextResponse.json({ error: "Failed to allocate surplus" }, { status: 500 })
     }
 
-    getPostHogClient().capture({
+    getPostHogClient(req.headers.get("cookie")).capture({
       distinctId: profile.profileId,
       event: "budget_surplus_allocated",
       properties: { week_start_date: weekStart, duplicate: result.duplicate ?? false },

--- a/app/api/maps/route.ts
+++ b/app/api/maps/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
+import { parseCookieConsentFromCookieHeader } from "@/lib/privacy/cookie-consent"
 
 const API_KEY =
   process.env.GOOGLE_MAPS_SERVER_KEY ||
@@ -22,6 +23,14 @@ const buildUrl = (base: string, params: Record<string, string | number | undefin
 export async function POST(request: NextRequest) {
   if (!API_KEY) {
     return NextResponse.json({ error: "Google Maps API key is not configured." }, { status: 500 })
+  }
+
+  const thirdPartyAllowed = parseCookieConsentFromCookieHeader(request.headers.get("cookie"))?.thirdParty ?? false
+  if (!thirdPartyAllowed) {
+    return NextResponse.json(
+      { error: "Third-party map services are disabled until cookie consent is granted." },
+      { status: 403 }
+    )
   }
 
   let body: { action?: MapsAction; params?: Record<string, any> }

--- a/app/api/streaks/freeze/use/route.ts
+++ b/app/api/streaks/freeze/use/route.ts
@@ -41,7 +41,7 @@ export async function POST(req: Request) {
     if ("validationError" in result) return NextResponse.json({ error: result.validationError }, { status: 409 })
     if ("error" in result && result.error) return NextResponse.json({ error: "Failed to use freeze token" }, { status: 500 })
 
-    getPostHogClient().capture({
+    getPostHogClient(req.headers.get("cookie")).capture({
       distinctId: profile.profileId,
       event: "streak_freeze_used",
       properties: { streak_date: streakDate },

--- a/app/api/streaks/grace/apply/route.ts
+++ b/app/api/streaks/grace/apply/route.ts
@@ -41,7 +41,7 @@ export async function POST(req: Request) {
     if ("validationError" in result) return NextResponse.json({ error: result.validationError }, { status: 409 })
     if ("error" in result && result.error) return NextResponse.json({ error: "Failed to apply grace skip" }, { status: 500 })
 
-    getPostHogClient().capture({
+    getPostHogClient(req.headers.get("cookie")).capture({
       distinctId: profile.profileId,
       event: "streak_grace_applied",
       properties: { streak_date: streakDate },

--- a/app/api/streaks/manual-confirm/route.ts
+++ b/app/api/streaks/manual-confirm/route.ts
@@ -43,7 +43,7 @@ export async function POST(req: Request) {
     if ("validationError" in result) return NextResponse.json({ error: result.validationError }, { status: 409 })
     if ("error" in result && result.error) return NextResponse.json({ error: "Failed to confirm meal" }, { status: 500 })
 
-    getPostHogClient().capture({
+    getPostHogClient(req.headers.get("cookie")).capture({
       distinctId: profile.profileId,
       event: "meal_verification_confirmed",
       properties: { source: "manual", already_counted: result.alreadyCounted },

--- a/app/api/streaks/verification/[id]/confirm/route.ts
+++ b/app/api/streaks/verification/[id]/confirm/route.ts
@@ -43,7 +43,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
     if ("validationError" in result) return NextResponse.json({ error: result.validationError }, { status: 409 })
     if ("error" in result && result.error) return NextResponse.json({ error: "Failed to confirm verification" }, { status: 500 })
 
-    getPostHogClient().capture({
+    getPostHogClient(req.headers.get("cookie")).capture({
       distinctId: profile.profileId,
       event: "streak_day_counted",
       properties: { already_counted: result.alreadyCounted ?? false },

--- a/app/api/streaks/verification/create/route.ts
+++ b/app/api/streaks/verification/create/route.ts
@@ -47,7 +47,7 @@ export async function POST(req: Request) {
     if ("validationError" in result) return NextResponse.json({ error: result.validationError }, { status: 409 })
     if ("error" in result && result.error) return NextResponse.json({ error: "Failed to create verification task" }, { status: 500 })
 
-    getPostHogClient().capture({
+    getPostHogClient(req.headers.get("cookie")).capture({
       distinctId: profile.profileId,
       event: "meal_verification_started",
       properties: { source: mediaAssetId ? "photo" : "manual", duplicate: result.duplicate ?? false },

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -153,7 +153,7 @@ export async function POST(request: NextRequest) {
 
         // Track subscription activation server-side
         if (supabaseUserId) {
-          const posthog = getPostHogClient()
+          const posthog = getPostHogClient(request.headers.get("cookie"))
           posthog.capture({
             distinctId: supabaseUserId,
             event: "subscription_activated",

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -14,7 +14,7 @@ import { Label } from "@/components/ui/label"
 import { useToast } from "@/hooks/ui/use-toast"
 import Image from "next/image"
 import { ArrowRight, X } from "lucide-react"
-import posthog from "posthog-js"
+import { capturePosthogEvent } from "@/lib/analytics/posthog-client"
 import { ensureProfileWithTimeout } from "@/lib/auth/ensure-profile-client"
 import { isProfileOnboardingComplete } from "@/lib/auth/onboarding"
 
@@ -118,7 +118,7 @@ export default function SignInPage() {
 
     await setActive({ session: createdSessionId })
     const payload = await ensureProfileWithTimeout()
-    posthog.capture("user_signed_in", { method: "email" })
+    capturePosthogEvent("user_signed_in", { method: "email" })
     toast({
       title: "Welcome Back",
       description: "Access granted.",

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -15,7 +15,7 @@ import Image from "next/image"
 import { ArrowRight } from "lucide-react"
 import { normalizeUsername, validateUsername } from "@/lib/auth/username"
 import { ensureProfileWithTimeout } from "@/lib/auth/ensure-profile-client"
-import posthog from "posthog-js"
+import { capturePosthogEvent, identifyPosthogUser } from "@/lib/analytics/posthog-client"
 
 export default function SignUpPage() {
   const [email, setEmail] = useState("")
@@ -81,8 +81,8 @@ export default function SignUpPage() {
       if (result.status === "complete" && result.createdSessionId) {
         await setActive({ session: result.createdSessionId })
         await ensureProfile(normalizedUsername)
-        posthog.identify(normalizedUsername, { email, username: normalizedUsername })
-        posthog.capture("user_signed_up", { method: "email", username: normalizedUsername })
+        identifyPosthogUser(normalizedUsername, { email, username: normalizedUsername })
+        capturePosthogEvent("user_signed_up", { method: "email", username: normalizedUsername })
         toast({
           title: "Account created!",
           description: "Let's set up your preferences.",
@@ -95,7 +95,7 @@ export default function SignUpPage() {
         strategy: "email_code",
       })
 
-      posthog.capture("user_signed_up", { method: "email", username: normalizedUsername })
+      capturePosthogEvent("user_signed_up", { method: "email", username: normalizedUsername })
       toast({
         title: "Check your email",
         description: "Enter the verification code we sent to finish creating your account.",

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -4,7 +4,7 @@ import { useTransition, useEffect, useState } from "react"
 import Link from "next/link"
 import { useSearchParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
-import posthog from "posthog-js"
+import { capturePosthogEvent } from "@/lib/analytics/posthog-client"
 
 export default function CheckoutPage() {
   const [isPending, startTransition] = useTransition()
@@ -49,7 +49,7 @@ export default function CheckoutPage() {
   }, [searchParams])
 
   const handleCheckout = () => {
-    posthog.capture("subscription_checkout_started", {
+    capturePosthogEvent("subscription_checkout_started", {
       item_count: pricingInfo.itemCount,
       total_amount: pricingInfo.totalAmount,
     })

--- a/app/checkout/success/page.tsx
+++ b/app/checkout/success/page.tsx
@@ -4,14 +4,14 @@ import { useEffect } from "react"
 import Link from "next/link"
 import { useSearchParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
-import posthog from "posthog-js"
+import { capturePosthogEvent } from "@/lib/analytics/posthog-client"
 
 export default function CheckoutSuccessPage() {
   const searchParams = useSearchParams()
   const sessionId = searchParams.get("session_id")
 
   useEffect(() => {
-    posthog.capture("subscription_purchased", { session_id: sessionId ?? undefined })
+    capturePosthogEvent("subscription_purchased", { session_id: sessionId ?? undefined })
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -36,4 +36,3 @@ export default function CheckoutSuccessPage() {
     </main>
   )
 }
-

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,8 @@
 import type React from "react"
 import type { Metadata, Viewport } from "next"
 import { ClerkProvider } from "@clerk/nextjs"
+import { cookies } from "next/headers"
 import { Inter, Playfair_Display } from "next/font/google"
-import Script from "next/script"
 import "./globals.css"
 import { AuthProvider } from "@/contexts/auth-context"
 import { PostHogProvider } from "@/contexts/posthog-provider"
@@ -11,7 +11,6 @@ import { QueryProvider } from "@/contexts/query-provider"
 import { Header } from "@/components/layout/header"
 import { AppFooter } from "@/components/layout/app-footer"
 import { Toaster } from "@/components/ui/toaster"
-import { SpeedInsights } from "@vercel/speed-insights/next"
 import { ErrorBoundary } from "@/components/shared/error-boundary"
 import { ThemeSync } from "@/components/providers/theme-sync"
 import { OnboardingRedirect } from "@/components/providers/onboarding-redirect"
@@ -20,6 +19,10 @@ import { TutorialProvider } from "@/contexts/tutorial-context"
 import { TutorialOverlay } from "@/components/tutorial/tutorial-overlay"
 // Removed TutorialBlocker import
 import { FeedbackWidget } from "@/components/tutorial/feedback-widget"
+import { CookieConsentBanner } from "@/components/privacy/cookie-consent-banner"
+import { CookieConsentProvider } from "@/contexts/cookie-consent-context"
+import { SpeedInsightsGate } from "@/components/privacy/speed-insights-gate"
+import { parseCookieConsentCookieValue, COOKIE_CONSENT_COOKIE } from "@/lib/privacy/cookie-consent"
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" })
 const playfair = Playfair_Display({ subsets: ["latin"], variable: "--font-playfair" })
@@ -66,38 +69,34 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  console.log("--- LAYOUT STARTING ---")
-  const googleMapsKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+  const consentCookie = cookies().get(COOKIE_CONSENT_COOKIE)?.value ?? null
+  const initialConsent = parseCookieConsentCookieValue(consentCookie)
 
   return (
     <ClerkProvider>
       <html lang="en" suppressHydrationWarning>
         <body className={`${inter.variable} ${playfair.variable} font-sans antialiased`}>
-          {/* Google Maps API - in body so layout chunk load isn't blocked */}
-          {googleMapsKey && (
-            <Script
-              src={`https://maps.googleapis.com/maps/api/js?key=${googleMapsKey}&libraries=places`}
-              strategy="lazyOnload"
-            />
-          )}
           <ErrorBoundary>
             <ThemeProvider>
               <QueryProvider>
                 <AuthProvider>
-                  <PostHogProvider>
-                    <TutorialProvider>
-                      <ThemeSync />
-                      <OnboardingRedirect />
-                      <PretextBootstrap />
-                      <TutorialOverlay />
-                      <FeedbackWidget position="bottom-left" />
-                      <Header />
-                      {children}
-                      <AppFooter />
-                      <Toaster />
-                      <SpeedInsights />
-                    </TutorialProvider>
-                  </PostHogProvider>
+                  <CookieConsentProvider initialConsent={initialConsent}>
+                    <PostHogProvider>
+                      <TutorialProvider>
+                        <ThemeSync />
+                        <OnboardingRedirect />
+                        <PretextBootstrap />
+                        <TutorialOverlay />
+                        <FeedbackWidget position="bottom-left" />
+                        <Header />
+                        {children}
+                        <AppFooter />
+                        <Toaster />
+                        <SpeedInsightsGate />
+                        <CookieConsentBanner />
+                      </TutorialProvider>
+                    </PostHogProvider>
+                  </CookieConsentProvider>
                 </AuthProvider>
               </QueryProvider>
             </ThemeProvider>

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -11,7 +11,7 @@ import { ChefHat, DollarSign, Users, MapPin, Clock, ArrowLeft, ArrowRight, Loade
 import { useAuth } from "@/contexts/auth-context"
 import { useToast } from "@/hooks/ui/use-toast"
 import { useTheme } from "@/contexts/theme-context"
-import { AddressAutocomplete } from "@/components/shared/address-autocomplete"
+import { AddressAutocompleteWithConsent } from "@/components/shared/address-autocomplete-with-consent"
 import { DIETARY_TAGS, CUISINE_TYPES, type DifficultyLevel } from "@/lib/types"
 const goals = [
   {
@@ -558,24 +558,21 @@ export default function OnboardingPage() {
                 <Label htmlFor="address" className={`mb-1 block ${isDark ? "text-[#e8dcc4]" : "text-amber-950"}`}>
                   Address search
                 </Label>
-                <div className="relative">
-                  <MapPin className={`absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 ${isDark ? "text-[#e8dcc4]/40" : "text-orange-700"}`} />
-                  <AddressAutocomplete
-                    value={{
-                      formattedAddress,
-                      addressLine1,
-                      addressLine2,
-                      city,
-                      state: stateRegion,
-                      postalCode,
-                      country,
-                      lat,
-                      lng,
-                    }}
-                    onChange={handleAddressChange}
-                    placeholder="Search your address"
-                  />
-                </div>
+                <AddressAutocompleteWithConsent
+                  value={{
+                    formattedAddress,
+                    addressLine1,
+                    addressLine2,
+                    city,
+                    state: stateRegion,
+                    postalCode,
+                    country,
+                    lat,
+                    lng,
+                  }}
+                  onChange={handleAddressChange}
+                  placeholder="Search your address"
+                />
                 <p className={`hidden text-xs sm:block ${isDark ? "text-[#e8dcc4]/40" : "text-amber-900"}`}>Use the search to auto-complete your address for better store accuracy.</p>
               </div>
               <div className="grid grid-cols-2 gap-2 sm:gap-3">

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -5,19 +5,35 @@ export default function PrivacyPage() {
     <InfoPage
       eyebrow="Legal"
       title="Privacy Policy"
-      description="This starter privacy page summarizes the types of data Secret Sauce may use to provide cooking, planning, shopping, and account features."
+      description="This page explains what Secret Sauce collects, why it is collected, and how you can control optional cookies and third-party services."
       sections={[
         {
-          title: "Information we use",
-          body: "Secret Sauce may use account details, recipe activity, pantry entries, meal plans, grocery preferences, location preferences, and feedback you submit.",
+          title: "Information we collect",
+          body: "Secret Sauce may process account details, authentication/session data, recipe activity, social activity, pantry entries, meal plans, grocery preferences, feedback, and device or usage information needed to operate the product.",
         },
         {
-          title: "Why it is used",
-          body: "This information supports core product features such as recommendations, grocery comparisons, saved preferences, account security, and product improvement.",
+          title: "Cookies and local storage",
+          body: "Necessary cookies keep sign-in, security, and basic site functionality working. If you opt in, optional analytics cookies may be used for product analytics and third-party cookies may be used for services such as maps, routing, and address autocomplete. The site also uses browser storage for product preferences and UI state, including tutorial progress, temporary drafts, and cached interface data.",
         },
         {
-          title: "Third-party services",
-          body: "The app may rely on providers for authentication, hosting, analytics, payments, maps, storage, and database services. Those services process data needed for their role.",
+          title: "Why we use this information",
+          body: "We use this information to authenticate users, provide recipes and social features, save preferences, support grocery and meal-planning tools, improve reliability, and understand how the product is used when analytics is enabled.",
+        },
+        {
+          title: "Third-party processors",
+          body: "Secret Sauce may rely on providers for authentication, hosting, analytics, maps, routing, payments, storage, and database services. These providers process data only to provide the services we use them for. Analytics and map services are not loaded unless you opt in through cookie settings.",
+        },
+        {
+          title: "Retention and deletion",
+          body: "We keep data only as long as needed for the product, legal, security, and operational purposes described here. Some content can be removed or restored by administrators, while account and transactional records may be retained for security, audit, or legal reasons.",
+        },
+        {
+          title: "Your choices",
+          body: "You can use cookie settings to allow or disable optional analytics and third-party cookies at any time. You can also manage account settings, sign out, and contact us if you want help accessing, correcting, or deleting information where applicable.",
+        },
+        {
+          title: "Contact",
+          body: "For privacy questions, use the Contact page or reach out through the support channels listed in the app. If you change your mind about cookie preferences, use Cookie settings in the footer or Settings page.",
         },
       ]}
     />

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -15,7 +15,8 @@ import { Accessibility, Bell, BookOpen, FileText, HelpCircle, Info, Lock, LogOut
 import { supabase } from "@/lib/database/supabase"
 import { profileDB, type Profile } from "@/lib/database/profile-db"
 import { TutorialSelectionModal } from "@/components/tutorial/tutorial-selection-modal"
-import { AddressAutocomplete } from "@/components/shared/address-autocomplete"
+import { AddressAutocompleteWithConsent } from "@/components/shared/address-autocomplete-with-consent"
+import { CookieSettingsButton } from "@/components/privacy/cookie-settings-button"
 import { useToast } from "@/hooks"
 import { AuthGate } from "@/components/auth/tier-gate"
 import { useRouter } from "next/navigation"
@@ -779,7 +780,7 @@ function SettingsPageContent() {
           <CardContent className={sectionContentClass}>
             <div className="space-y-2">
               <Label className="text-sm font-medium text-foreground">Home address</Label>
-              <AddressAutocomplete
+              <AddressAutocompleteWithConsent
                 value={{
                   formattedAddress,
                   addressLine1,
@@ -1034,6 +1035,7 @@ function SettingsPageContent() {
               <MessageCircle className="h-4 w-4" />
               Send Feedback
             </Button>
+            <CookieSettingsButton className="mt-2 min-h-12 w-full justify-start gap-3 rounded-md border px-3 py-2 text-sm font-medium text-foreground hover:bg-muted/50 hover:text-foreground" />
           </CardContent>
         </Card>
 

--- a/app/store/page.tsx
+++ b/app/store/page.tsx
@@ -3,12 +3,14 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@/contexts/auth-context"
+import { useCookieConsent } from "@/contexts/cookie-consent-context"
 import { useTheme } from "@/contexts/theme-context"
 import { useToast } from "@/hooks"
 import { useShoppingList } from "@/hooks/shopping/use-shopping-list"
 import { useStoreComparison } from "@/hooks/shopping/use-store-comparison"
 import { updateLocation, getUserLocation, reverseGeocodeToPostalCode } from "@/lib/location-client"
 import dynamic from "next/dynamic"
+import { CookieSettingsButton } from "@/components/privacy/cookie-settings-button"
 import { ShoppingReceiptView } from "@/components/store/shopping-receipt-view"
 import { ItemReplacementModal } from "@/components/store/store-replacement"
 import { MobileQuickAddPanel } from "@/components/store/mobile-quick-add-panel"
@@ -61,6 +63,7 @@ function buildListQuantitySignature(items: Array<{ id: string; quantity?: number
 export default function ShoppingReceiptPage() {
   const router = useRouter()
   const { user } = useAuth()
+  const { thirdPartyAllowed } = useCookieConsent()
   const { theme } = useTheme()
   const { toast } = useToast()
   const [mounted, setMounted] = useState(false)
@@ -509,7 +512,7 @@ export default function ShoppingReceiptPage() {
             />
 
             {/* Map: desktop sidebar only */}
-            {visibleStoreComparisons.length > 0 && (
+            {visibleStoreComparisons.length > 0 && thirdPartyAllowed && (
               <div className={`hidden lg:block rounded-lg overflow-hidden border ${
                 isDark ? "border-white/10 bg-[#1f1e1a]" : "border-gray-200 bg-white"
               }`} data-tutorial="store-map">
@@ -522,6 +525,18 @@ export default function ShoppingReceiptPage() {
                 />
               </div>
             )}
+            {visibleStoreComparisons.length > 0 && !thirdPartyAllowed ? (
+              <div className={`hidden lg:block rounded-lg border p-4 ${
+                isDark ? "border-white/10 bg-[#1f1e1a] text-[#e8dcc4]/80" : "border-gray-200 bg-white text-gray-700"
+              }`}>
+                <p className="text-sm font-medium">Map features are disabled</p>
+                <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                  Store maps, routing, and address lookups use third-party services. Enable third-party cookies
+                  in cookie settings to load them.
+                </p>
+                <CookieSettingsButton className="mt-3 text-xs" />
+              </div>
+            ) : null}
           </aside>
 
           {/* Receipt view */}

--- a/app/upload-recipe/page.tsx
+++ b/app/upload-recipe/page.tsx
@@ -14,7 +14,7 @@ import { RecipeManualEntryForm } from "@/components/recipe/forms/recipe-manual-e
 import { RecipeImportTabs } from "@/components/recipe/import/recipe-import-tabs"
 import { RecipeImportParagraph } from "@/components/recipe/import/recipe-import-paragraph"
 import type { ImportedRecipe, RecipeSubmissionData } from "@/lib/types"
-import posthog from "posthog-js"
+import { capturePosthogEvent } from "@/lib/analytics/posthog-client"
 
 export default function UploadRecipePage() {
   const router = useRouter()
@@ -58,7 +58,7 @@ export default function UploadRecipePage() {
 
     setFormData(data)
     setMainTab("manual")
-    posthog.capture("recipe_imported", { source: shareImport === "instagram" ? "instagram" : "url" })
+    capturePosthogEvent("recipe_imported", { source: shareImport === "instagram" ? "instagram" : "url" })
   }
 
   const handleSubmit = async (submissionData: RecipeSubmissionData) => {
@@ -103,7 +103,7 @@ export default function UploadRecipePage() {
 
       if (!newRecipe) throw new Error("Failed to create recipe record")
 
-      posthog.capture("recipe_created", {
+      capturePosthogEvent("recipe_created", {
         recipe_id: newRecipe.id,
         method: formData ? "import" : "manual",
       })

--- a/components/layout/app-footer.tsx
+++ b/components/layout/app-footer.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { MessageCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { CookieSettingsButton } from "@/components/privacy/cookie-settings-button"
 
 const footerGroups = [
   {
@@ -90,6 +91,11 @@ export function AppFooter() {
                     </Link>
                   </li>
                 ))}
+                {group.title === "Legal" ? (
+                  <li>
+                    <CookieSettingsButton className="text-sm text-muted-foreground hover:text-foreground" />
+                  </li>
+                ) : null}
               </ul>
             </div>
           ))}

--- a/components/privacy/cookie-consent-banner.tsx
+++ b/components/privacy/cookie-consent-banner.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { ShieldCheck, SlidersHorizontal } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { useCookieConsent } from "@/contexts/cookie-consent-context"
+
+export function CookieConsentBanner() {
+  const {
+    preferences,
+    preferencesDialogOpen,
+    openPreferences,
+    closePreferences,
+    savePreferences,
+    acceptAll,
+    acceptNecessaryOnly,
+  } = useCookieConsent()
+
+  const [analytics, setAnalytics] = useState(false)
+  const [thirdParty, setThirdParty] = useState(false)
+
+  const bannerVisible = preferences === null
+
+  useEffect(() => {
+    if (!preferencesDialogOpen) return
+    setAnalytics(preferences?.analytics ?? false)
+    setThirdParty(preferences?.thirdParty ?? false)
+  }, [preferences?.analytics, preferences?.thirdParty, preferencesDialogOpen])
+
+  const summary = useMemo(() => {
+    if (preferences === null) {
+      return "Necessary cookies keep your sign-in and security working. Analytics and third-party map cookies stay off until you choose."
+    }
+
+    if (!preferences.analytics && !preferences.thirdParty) {
+      return "You are currently using necessary-only cookies."
+    }
+
+    if (preferences.analytics && preferences.thirdParty) {
+      return "Analytics and third-party cookies are enabled."
+    }
+
+    return "Your cookie preferences are saved."
+  }, [preferences])
+
+  return (
+    <>
+      {bannerVisible ? (
+        <div className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-background/98 px-4 py-4 shadow-[0_-12px_48px_rgba(0,0,0,0.12)] backdrop-blur">
+          <div className="mx-auto flex max-w-6xl flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="max-w-2xl space-y-1">
+              <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                <ShieldCheck className="h-4 w-4 text-emerald-600" />
+                Cookie preferences
+              </div>
+              <p className="text-sm text-muted-foreground">{summary}</p>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button type="button" variant="outline" onClick={acceptNecessaryOnly}>
+                Necessary only
+              </Button>
+              <Button type="button" onClick={acceptAll}>
+                Accept all
+              </Button>
+              <Button type="button" variant="ghost" className="gap-2" onClick={openPreferences}>
+                <SlidersHorizontal className="h-4 w-4" />
+                Customize
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <Dialog open={preferencesDialogOpen} onOpenChange={(open) => (open ? openPreferences() : closePreferences())}>
+        <DialogContent className="sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Cookie settings</DialogTitle>
+            <DialogDescription>
+              Control analytics and third-party services. Necessary cookies stay enabled for sign-in and
+              security.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+              <div className="space-y-1">
+                <Label className="text-sm font-medium text-foreground">Analytics cookies</Label>
+                <p className="text-sm text-muted-foreground">
+                  Enables PostHog page tracking and related product analytics.
+                </p>
+              </div>
+              <Switch checked={analytics} onCheckedChange={setAnalytics} />
+            </div>
+
+            <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+              <div className="space-y-1">
+                <Label className="text-sm font-medium text-foreground">Third-party cookies</Label>
+                <p className="text-sm text-muted-foreground">
+                  Enables third-party map, routing, and address lookup features.
+                </p>
+              </div>
+              <Switch checked={thirdParty} onCheckedChange={setThirdParty} />
+            </div>
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button type="button" variant="outline" onClick={acceptNecessaryOnly}>
+              Necessary only
+            </Button>
+            <Button type="button" variant="outline" onClick={acceptAll}>
+              Accept all
+            </Button>
+            <Button
+              type="button"
+              onClick={() => savePreferences({ analytics, thirdParty })}
+            >
+              Save preferences
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/components/privacy/cookie-settings-button.tsx
+++ b/components/privacy/cookie-settings-button.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import type React from "react"
+import { Button } from "@/components/ui/button"
+import { useCookieConsent } from "@/contexts/cookie-consent-context"
+import { cn } from "@/lib/utils"
+
+type CookieSettingsButtonProps = {
+  className?: string
+  children?: React.ReactNode
+}
+
+export function CookieSettingsButton({
+  className,
+  children = "Cookie settings",
+}: CookieSettingsButtonProps) {
+  const { openPreferences } = useCookieConsent()
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      className={cn(
+        "h-auto justify-start px-0 py-0 text-sm font-normal text-muted-foreground hover:bg-transparent hover:text-foreground",
+        className,
+      )}
+      onClick={openPreferences}
+    >
+      {children}
+    </Button>
+  )
+}
+

--- a/components/privacy/speed-insights-gate.tsx
+++ b/components/privacy/speed-insights-gate.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import { SpeedInsights } from "@vercel/speed-insights/next"
+import { useCookieConsent } from "@/contexts/cookie-consent-context"
+
+export function SpeedInsightsGate() {
+  const { analyticsAllowed } = useCookieConsent()
+
+  if (!analyticsAllowed) return null
+
+  return <SpeedInsights />
+}
+

--- a/components/shared/address-autocomplete-with-consent.tsx
+++ b/components/shared/address-autocomplete-with-consent.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Script from "next/script"
+import { MapPin } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { CookieSettingsButton } from "@/components/privacy/cookie-settings-button"
+import { useCookieConsent } from "@/contexts/cookie-consent-context"
+import {
+  AddressAutocomplete,
+  type AddressAutocompleteProps,
+} from "@/components/shared/address-autocomplete"
+
+type AddressAutocompleteWithConsentProps = AddressAutocompleteProps
+
+export function AddressAutocompleteWithConsent(props: AddressAutocompleteWithConsentProps) {
+  const { thirdPartyAllowed } = useCookieConsent()
+  const [mapsReady, setMapsReady] = useState(false)
+  const mapsKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+
+  useEffect(() => {
+    if (!thirdPartyAllowed) {
+      setMapsReady(false)
+      return
+    }
+
+    if (typeof window !== "undefined" && window.google?.maps?.places?.Autocomplete) {
+      setMapsReady(true)
+    }
+  }, [thirdPartyAllowed])
+
+  if (!thirdPartyAllowed || !mapsKey) {
+    return (
+      <div className="space-y-2">
+        <div className="relative">
+          <MapPin className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder={props.placeholder ?? "Enter your address"}
+            disabled={props.disabled}
+            value={props.value?.formattedAddress || props.value?.addressLine1 || ""}
+            onChange={(event) =>
+              props.onChange({
+                ...props.value,
+                formattedAddress: event.target.value,
+              })
+            }
+            className="pl-10"
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Address autocomplete uses third-party map services and is disabled until you allow third-party cookies.
+        </p>
+        <CookieSettingsButton className="text-xs" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <Script
+        src={`https://maps.googleapis.com/maps/api/js?key=${mapsKey}&libraries=places`}
+        strategy="afterInteractive"
+        onLoad={() => setMapsReady(true)}
+      />
+      <AddressAutocomplete {...props} mapsReady={mapsReady} />
+    </div>
+  )
+}

--- a/components/shared/address-autocomplete.tsx
+++ b/components/shared/address-autocomplete.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input"
 
 declare const google: any
 
-type ParsedAddress = {
+export type ParsedAddress = {
   formattedAddress: string
   addressLine1?: string
   addressLine2?: string
@@ -17,11 +17,12 @@ type ParsedAddress = {
   lng?: number | null
 }
 
-interface AddressAutocompleteProps {
+export interface AddressAutocompleteProps {
   value: ParsedAddress
   onChange: (address: ParsedAddress) => void
   placeholder?: string
   disabled?: boolean
+  mapsReady?: boolean
 }
 
 const componentMap: Record<string, keyof ParsedAddress> = {
@@ -72,7 +73,7 @@ function parsePlace(place: any): ParsedAddress {
   return parsed
 }
 
-export function AddressAutocomplete({ value, onChange, placeholder, disabled }: AddressAutocompleteProps) {
+export function AddressAutocomplete({ value, onChange, placeholder, disabled, mapsReady }: AddressAutocompleteProps) {
   const inputRef = useRef<HTMLInputElement | null>(null)
   const controlledValue = useMemo(
     () => value?.formattedAddress || value?.addressLine1 || "",
@@ -88,6 +89,7 @@ export function AddressAutocomplete({ value, onChange, placeholder, disabled }: 
 
   useEffect(() => {
     if (typeof window === "undefined") return
+    if (!mapsReady) return
     const inputEl = inputRef.current
     if (!inputEl) return
     if (!window.google?.maps?.places?.Autocomplete) return
@@ -114,7 +116,7 @@ export function AddressAutocomplete({ value, onChange, placeholder, disabled }: 
     }
     // Only recreate autocomplete if onChange function identity changes (not on every value update)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onChange])
+  }, [mapsReady, onChange])
 
   return (
     <Input

--- a/contexts/cookie-consent-context.tsx
+++ b/contexts/cookie-consent-context.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import type React from "react"
+import { createContext, useContext, useMemo, useState } from "react"
+import {
+  type CookieConsentPreferences,
+  writeCookieConsentToDocument,
+} from "@/lib/privacy/cookie-consent"
+
+type CookieConsentContextValue = {
+  preferences: CookieConsentPreferences | null
+  analyticsAllowed: boolean
+  thirdPartyAllowed: boolean
+  preferencesDialogOpen: boolean
+  openPreferences: () => void
+  closePreferences: () => void
+  savePreferences: (input: { analytics: boolean; thirdParty: boolean }) => void
+  acceptAll: () => void
+  acceptNecessaryOnly: () => void
+}
+
+const CookieConsentContext = createContext<CookieConsentContextValue | undefined>(undefined)
+
+export function CookieConsentProvider({
+  children,
+  initialConsent,
+}: {
+  children: React.ReactNode
+  initialConsent: CookieConsentPreferences | null
+}) {
+  const [preferences, setPreferences] = useState<CookieConsentPreferences | null>(initialConsent)
+  const [preferencesDialogOpen, setPreferencesDialogOpen] = useState(false)
+
+  const savePreferences = (input: { analytics: boolean; thirdParty: boolean }) => {
+    const next = writeCookieConsentToDocument(input)
+    setPreferences(next)
+    setPreferencesDialogOpen(false)
+  }
+
+  const value = useMemo<CookieConsentContextValue>(
+    () => ({
+      preferences,
+      analyticsAllowed: preferences?.analytics ?? false,
+      thirdPartyAllowed: preferences?.thirdParty ?? false,
+      preferencesDialogOpen,
+      openPreferences: () => setPreferencesDialogOpen(true),
+      closePreferences: () => setPreferencesDialogOpen(false),
+      savePreferences,
+      acceptAll: () => {
+        savePreferences({ analytics: true, thirdParty: true })
+        setPreferencesDialogOpen(false)
+      },
+      acceptNecessaryOnly: () => {
+        savePreferences({ analytics: false, thirdParty: false })
+        setPreferencesDialogOpen(false)
+      },
+    }),
+    [preferences, preferencesDialogOpen],
+  )
+
+  return <CookieConsentContext.Provider value={value}>{children}</CookieConsentContext.Provider>
+}
+
+export function useCookieConsent(): CookieConsentContextValue {
+  const context = useContext(CookieConsentContext)
+  if (!context) {
+    throw new Error("useCookieConsent must be used within a CookieConsentProvider")
+  }
+  return context
+}

--- a/contexts/posthog-provider.tsx
+++ b/contexts/posthog-provider.tsx
@@ -1,33 +1,35 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import posthog from "posthog-js"
 import { PostHogProvider as PHProvider, usePostHog } from "posthog-js/react"
 import { usePathname, useSearchParams } from "next/navigation"
 import { Suspense } from "react"
 import { useAuth } from "./auth-context"
+import { useCookieConsent } from "@/contexts/cookie-consent-context"
+import { resetPosthogClient } from "@/lib/analytics/posthog-client"
 
-function PostHogPageView() {
+function PostHogPageView({ enabled }: { enabled: boolean }) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const posthogClient = usePostHog()
 
   useEffect(() => {
-    if (pathname && posthogClient) {
+    if (enabled && pathname && posthogClient) {
       const url = `${pathname}${searchParams?.toString() ? `?${searchParams.toString()}` : ""}`
       posthogClient.capture("$pageview", { $current_url: url })
     }
-  }, [pathname, searchParams, posthogClient])
+  }, [enabled, pathname, searchParams, posthogClient])
 
   return null
 }
 
-function PostHogIdentify() {
+function PostHogIdentify({ enabled }: { enabled: boolean }) {
   const { user, profile, loading } = useAuth()
   const posthogClient = usePostHog()
 
   useEffect(() => {
-    if (loading || !posthogClient) return
+    if (!enabled || loading || !posthogClient) return
 
     if (user) {
       posthogClient.identify(user.id, {
@@ -37,17 +39,30 @@ function PostHogIdentify() {
     } else {
       posthogClient.reset()
     }
-  }, [user, profile, loading, posthogClient])
+  }, [enabled, user, profile, loading, posthogClient])
 
   return null
 }
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  const { analyticsAllowed } = useCookieConsent()
+  const [analyticsReady, setAnalyticsReady] = useState(false)
+
   useEffect(() => {
     const key = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
     const host = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com"
 
     if (!key) return
+
+    if (!analyticsAllowed) {
+      if (analyticsReady) {
+        resetPosthogClient()
+        setAnalyticsReady(false)
+      }
+      return
+    }
+
+    if (analyticsReady) return
 
     posthog.init(key, {
       api_host: host,
@@ -55,14 +70,15 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       capture_pageleave: true,
       person_profiles: "identified_only",
     })
-  }, [])
+    setAnalyticsReady(true)
+  }, [analyticsAllowed, analyticsReady])
 
   return (
     <PHProvider client={posthog}>
       <Suspense fallback={null}>
-        <PostHogPageView />
+        <PostHogPageView enabled={analyticsAllowed && analyticsReady} />
       </Suspense>
-      <PostHogIdentify />
+      <PostHogIdentify enabled={analyticsAllowed && analyticsReady} />
       {children}
     </PHProvider>
   )

--- a/hooks/use-analytics.ts
+++ b/hooks/use-analytics.ts
@@ -3,6 +3,7 @@
 import { useCallback } from "react"
 import { usePostHog } from "posthog-js/react"
 import { useAuth } from "@/contexts/auth-context"
+import { useCookieConsent } from "@/contexts/cookie-consent-context"
 import type { AnalyticsEventName, EventProperties } from "@/lib/analytics"
 
 type SubscriptionTier = "free" | "premium"
@@ -10,15 +11,17 @@ type SubscriptionTier = "free" | "premium"
 export function useAnalytics() {
   const posthog = usePostHog()
   const { user, profile } = useAuth()
+  const { analyticsAllowed } = useCookieConsent()
 
   const trackEvent = useCallback(
     <T extends AnalyticsEventName>(
       eventName: T,
       properties?: EventProperties[T]
     ) => {
+      if (!analyticsAllowed) return
       posthog?.capture(eventName, properties)
     },
-    [posthog]
+    [analyticsAllowed, posthog]
   )
 
   return {

--- a/hooks/use-experiment.ts
+++ b/hooks/use-experiment.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useFeatureFlagPayload, usePostHog } from "posthog-js/react"
+import { useCookieConsent } from "@/contexts/cookie-consent-context"
 
 export interface UseExperimentOptions {
   enabled?: boolean
@@ -8,19 +9,23 @@ export interface UseExperimentOptions {
 
 export function useExperiment(flagKey: string, options: UseExperimentOptions = {}) {
   const { enabled = true } = options
+  const { analyticsAllowed } = useCookieConsent()
   const posthog = usePostHog()
-  const payload = useFeatureFlagPayload(enabled ? flagKey : "") as Record<string, unknown> | null | undefined
+  const effectiveEnabled = enabled && analyticsAllowed
+  const payload = useFeatureFlagPayload(effectiveEnabled ? flagKey : "") as Record<string, unknown> | null | undefined
 
   const variantConfig: Record<string, unknown> = payload && typeof payload === "object" ? payload : {}
   const variantName = (variantConfig.variant_name as string | undefined) ?? null
   const isControl = (variantConfig.is_control as boolean | undefined) ?? false
-  const variantKey = (enabled ? posthog?.getFeatureFlag(flagKey) : null) as string | null | undefined ?? null
+  const variantKey = (effectiveEnabled ? posthog?.getFeatureFlag(flagKey) : null) as string | null | undefined ?? null
 
   const trackConversion = (properties?: Record<string, unknown>) => {
+    if (!effectiveEnabled) return
     posthog?.capture("experiment_conversion", { flag_key: flagKey, ...properties })
   }
 
   const trackClick = (properties?: Record<string, unknown>) => {
+    if (!effectiveEnabled) return
     posthog?.capture("experiment_click", { flag_key: flagKey, ...properties })
   }
 

--- a/lib/analytics/posthog-client.ts
+++ b/lib/analytics/posthog-client.ts
@@ -1,0 +1,26 @@
+"use client"
+
+import posthog from "posthog-js"
+import { readCookieConsentFromDocument } from "@/lib/privacy/cookie-consent"
+
+function hasAnalyticsConsent(): boolean {
+  return readCookieConsentFromDocument()?.analytics ?? false
+}
+
+export function capturePosthogEvent(event: string, properties?: Record<string, unknown>) {
+  if (!hasAnalyticsConsent()) return
+  posthog.capture(event, properties)
+}
+
+export function identifyPosthogUser(distinctId: string, properties?: Record<string, unknown>) {
+  if (!hasAnalyticsConsent()) return
+  posthog.identify(distinctId, properties)
+}
+
+export function resetPosthogClient() {
+  posthog.reset()
+  if (typeof posthog.opt_out_capturing === "function") {
+    posthog.opt_out_capturing()
+  }
+}
+

--- a/lib/location-client.ts
+++ b/lib/location-client.ts
@@ -1,3 +1,5 @@
+import { readCookieConsentFromDocument } from "@/lib/privacy/cookie-consent"
+
 type LatLng = { lat: number; lng: number }
 
 type GoogleGeocodeResult = {
@@ -17,6 +19,7 @@ type GoogleGeocodeResponse = {
 async function geocodeAddress(address: string): Promise<LatLng | null> {
   const trimmed = address.trim()
   if (!trimmed) return null
+  if (!readCookieConsentFromDocument()?.thirdParty) return null
 
   try {
     const response = await fetch("/api/maps", {
@@ -47,6 +50,8 @@ export async function geocodePostalCode(input: string): Promise<LatLng | null> {
 }
 
 export async function reverseGeocodeToPostalCode(coords: LatLng): Promise<string | null> {
+  if (!readCookieConsentFromDocument()?.thirdParty) return null
+
   try {
     const response = await fetch("/api/maps", {
       method: "POST",

--- a/lib/posthog-server.ts
+++ b/lib/posthog-server.ts
@@ -1,3 +1,5 @@
+import { parseCookieConsentFromCookieHeader } from "@/lib/privacy/cookie-consent"
+
 type CaptureParams = {
   distinctId: string
   event: string
@@ -8,13 +10,14 @@ type CaptureParams = {
  * Minimal server-side PostHog capture using the REST API directly.
  * Used in API routes and webhooks where posthog-js is not available.
  */
-export function getPostHogClient() {
+export function getPostHogClient(cookieHeader?: string | null) {
   const token = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
   const host = process.env.NEXT_PUBLIC_POSTHOG_HOST
+  const analyticsAllowed = parseCookieConsentFromCookieHeader(cookieHeader)?.analytics ?? false
 
   return {
     capture({ distinctId, event, properties }: CaptureParams) {
-      if (!token || !host) return
+      if (!token || !host || !analyticsAllowed) return
       // Fire-and-forget; webhook handlers must not block on analytics
       fetch(`${host}/capture/`, {
         method: "POST",

--- a/lib/privacy/cookie-consent.ts
+++ b/lib/privacy/cookie-consent.ts
@@ -1,0 +1,112 @@
+export const COOKIE_CONSENT_COOKIE = "ss_cookie_consent"
+export const COOKIE_CONSENT_VERSION = 1 as const
+
+export type CookieConsentPreferences = {
+  version: typeof COOKIE_CONSENT_VERSION
+  analytics: boolean
+  thirdParty: boolean
+  updatedAt: string
+}
+
+type CookieConsentInput = {
+  analytics: boolean
+  thirdParty: boolean
+}
+
+function isBrowser(): boolean {
+  return typeof document !== "undefined"
+}
+
+function readCookieValue(cookieSource: string, name: string): string | null {
+  const prefix = `${name}=`
+  for (const part of cookieSource.split(";")) {
+    const trimmed = part.trim()
+    if (!trimmed.startsWith(prefix)) continue
+    return trimmed.slice(prefix.length)
+  }
+  return null
+}
+
+function decodeCookieValue(raw: string): string | null {
+  try {
+    return decodeURIComponent(raw)
+  } catch {
+    return raw
+  }
+}
+
+export function parseCookieConsentCookieValue(raw: string | null | undefined): CookieConsentPreferences | null {
+  if (!raw) return null
+
+  try {
+    const parsed = JSON.parse(decodeCookieValue(raw) ?? raw) as Partial<CookieConsentPreferences>
+    if (parsed?.version !== COOKIE_CONSENT_VERSION) return null
+    if (typeof parsed.analytics !== "boolean") return null
+    if (typeof parsed.thirdParty !== "boolean") return null
+
+    return {
+      version: COOKIE_CONSENT_VERSION,
+      analytics: parsed.analytics,
+      thirdParty: parsed.thirdParty,
+      updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : new Date().toISOString(),
+    }
+  } catch {
+    return null
+  }
+}
+
+export function parseCookieConsentFromCookieHeader(
+  cookieHeader: string | null | undefined,
+): CookieConsentPreferences | null {
+  if (!cookieHeader) return null
+  return parseCookieConsentCookieValue(readCookieValue(cookieHeader, COOKIE_CONSENT_COOKIE))
+}
+
+export function readCookieConsentFromDocument(): CookieConsentPreferences | null {
+  if (!isBrowser()) return null
+  return parseCookieConsentCookieValue(readCookieValue(document.cookie, COOKIE_CONSENT_COOKIE))
+}
+
+export function serializeCookieConsent(preferences: CookieConsentPreferences): string {
+  return encodeURIComponent(JSON.stringify(preferences))
+}
+
+export function writeCookieConsentToDocument(input: CookieConsentInput): CookieConsentPreferences {
+  const preferences: CookieConsentPreferences = {
+    version: COOKIE_CONSENT_VERSION,
+    analytics: input.analytics,
+    thirdParty: input.thirdParty,
+    updatedAt: new Date().toISOString(),
+  }
+
+  if (!isBrowser()) return preferences
+
+  const secure = window.location.protocol === "https:" ? "; Secure" : ""
+  document.cookie = [
+    `${COOKIE_CONSENT_COOKIE}=${serializeCookieConsent(preferences)}`,
+    "Path=/",
+    "Max-Age=31536000",
+    "SameSite=Lax",
+    secure ? secure.slice(2) : "",
+  ]
+    .filter(Boolean)
+    .join("; ")
+
+  return preferences
+}
+
+export function clearCookieConsentFromDocument(): void {
+  if (!isBrowser()) return
+
+  const secure = window.location.protocol === "https:" ? "; Secure" : ""
+  document.cookie = [
+    `${COOKIE_CONSENT_COOKIE}=`,
+    "Path=/",
+    "Max-Age=0",
+    "SameSite=Lax",
+    secure ? secure.slice(2) : "",
+  ]
+    .filter(Boolean)
+    .join("; ")
+}
+


### PR DESCRIPTION
## What changed
- Added a first-party cookie consent system with a banner, settings dialog, and persistent preferences cookie.
- Gated PostHog initialization, pageviews, identify calls, and server-side analytics behind analytics consent.
- Gated Google Maps, address autocomplete, store map features, and `/api/maps` behind third-party consent.
- Replaced the placeholder privacy page with a real privacy policy and added cookie settings entry points in the footer and settings page.

## Why
- The site was loading analytics and third-party map services before users had a chance to opt in.
- The previous privacy page was a placeholder and did not explain cookies, storage, or third-party processors.
- This updates the app to a more conservative and defensible privacy posture.

## Impact
- Necessary auth/session behavior remains intact.
- Analytics and third-party map services stay off until the user explicitly opts in.
- Users can review and change cookie preferences from the banner, footer, and settings page.

## Validation
- `git diff --check`
- Narrow `next lint` pass on the privacy/consent and store/map files
- Repo-wide lint still has unrelated existing indentation issues in older files